### PR TITLE
Begin mobile-first Timeline Editor transformation

### DIFF
--- a/css/studio-mobile-touch.css
+++ b/css/studio-mobile-touch.css
@@ -1,0 +1,138 @@
+/* Showduino Studio — mobile clip interaction affordances */
+
+.mobile-clip-actions {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  body.mobile-clip-gesture {
+    overscroll-behavior: none;
+    touch-action: none;
+  }
+
+  .timeline-editor .tl-clip::before,
+  .timeline-editor .tl-clip::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 18px;
+    z-index: 5;
+    pointer-events: none;
+  }
+
+  .timeline-editor .tl-clip::before {
+    left: 0;
+    border-left: 3px solid rgba(255, 255, 255, .7);
+    border-radius: 4px 0 0 4px;
+  }
+
+  .timeline-editor .tl-clip::after {
+    right: 0;
+    border-right: 3px solid rgba(255, 255, 255, .7);
+    border-radius: 0 4px 4px 0;
+  }
+
+  .timeline-editor .tl-clip.mobile-clip-armed {
+    filter: brightness(1.12);
+    outline: 2px solid rgba(0, 255, 204, .75);
+  }
+
+  .timeline-editor .tl-clip.mobile-clip-manipulating {
+    z-index: 500 !important;
+    opacity: .94;
+    outline: 2px solid #fff;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, .7), 0 0 0 3px rgba(0, 255, 204, .22);
+  }
+
+  .timeline-editor .tl-clip.mobile-clip-selected {
+    outline: 2px solid #fff;
+  }
+
+  .mobile-clip-actions {
+    position: fixed;
+    inset: auto 0 0 0;
+    z-index: 1500;
+    display: block;
+    padding: 8px 12px calc(16px + env(safe-area-inset-bottom));
+    border: 1px solid var(--daw-border, #394550);
+    border-radius: 18px 18px 0 0;
+    background: #182028;
+    box-shadow: 0 -22px 55px rgba(0, 0, 0, .72);
+    transform: translateY(105%);
+    transition: transform .22s ease;
+  }
+
+  .mobile-clip-actions.open {
+    transform: translateY(0);
+  }
+
+  .mobile-clip-actions-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .mobile-clip-actions-title strong,
+  .mobile-clip-actions-title span {
+    display: block;
+  }
+
+  .mobile-clip-actions-title strong {
+    color: #fff;
+    font-size: 1rem;
+  }
+
+  .mobile-clip-actions-title span {
+    margin-top: 2px;
+    color: #8f9ca7;
+    font-size: .75rem;
+  }
+
+  .mobile-clip-actions-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+  }
+
+  .mobile-clip-actions-grid button {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 76px;
+    border: 1px solid #394550;
+    border-radius: 11px;
+    background: #202a33;
+    color: #f3f6f8;
+  }
+
+  .mobile-clip-actions-grid button > span {
+    font-size: 1.25rem;
+  }
+
+  .mobile-clip-actions-grid button > strong {
+    font-size: .75rem;
+  }
+
+  .mobile-clip-actions-grid button:active,
+  .mobile-clip-actions-grid button:focus-visible {
+    border-color: var(--accent-color);
+    background: rgba(0, 255, 204, .1);
+    outline: none;
+  }
+
+  .mobile-clip-actions-grid button.danger {
+    border-color: rgba(255, 77, 77, .45);
+    color: #ff8a8a;
+  }
+
+  .mobile-clip-actions-grid button.danger:active,
+  .mobile-clip-actions-grid button.danger:focus-visible {
+    border-color: #ff4d4d;
+    background: rgba(255, 77, 77, .12);
+  }
+}

--- a/css/studio-mobile.css
+++ b/css/studio-mobile.css
@@ -3,8 +3,21 @@
 .mobile-menu-button,
 .mobile-sidebar-close,
 .mobile-action-bar,
-.mobile-sidebar-overlay {
+.mobile-sidebar-overlay,
+.mobile-track-picker {
   display: none;
+}
+
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
 }
 
 @media (max-width: 767px) {
@@ -199,6 +212,7 @@
     overscroll-behavior-x: contain;
     scrollbar-width: none;
     -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x proximity;
   }
 
   .timeline-editor .tl-toolbar::-webkit-scrollbar {
@@ -208,30 +222,30 @@
   .timeline-editor .tl-toolbar > *,
   .timeline-editor .btn-toolbar {
     flex: 0 0 auto;
+    scroll-snap-align: start;
   }
 
   .timeline-editor .btn-toolbar {
     min-width: 44px;
     min-height: 44px;
-    padding: .55rem .65rem;
+    padding: .55rem .65rem !important;
   }
 
   .timeline-editor .daw-shortcuts {
     display: none;
   }
 
-  .timeline-editor .tl-main,
-  .timeline-editor .tl-body,
-  .timeline-editor .tl-workspace {
+  /* Actual generated timeline DOM names. */
+  .timeline-editor .timeline-main {
     min-width: 0 !important;
     min-height: 0 !important;
     overflow: hidden !important;
   }
 
   .timeline-editor .tl-left {
-    width: 104px !important;
-    min-width: 104px !important;
-    max-width: 104px !important;
+    width: 112px !important;
+    min-width: 112px !important;
+    max-width: 112px !important;
     z-index: 4;
   }
 
@@ -239,25 +253,58 @@
     display: none !important;
   }
 
-  .timeline-editor .tl-track-header,
   .timeline-editor .tl-track-list-header {
-    min-width: 104px !important;
+    width: 112px !important;
+    min-width: 112px !important;
+    padding: 0 7px !important;
+  }
+
+  .timeline-editor .tl-track-list {
+    overflow-x: hidden !important;
+    scrollbar-width: none;
+  }
+
+  .timeline-editor .tl-track-list::-webkit-scrollbar {
+    display: none;
   }
 
   .timeline-editor .tl-track-header,
   .timeline-editor .tl-track-row {
-    min-height: 56px !important;
+    min-height: 60px !important;
+    height: 60px !important;
   }
 
-  .timeline-editor .tl-scroll,
-  .timeline-editor .tl-center,
-  .timeline-editor .tl-timeline,
-  .timeline-editor .tl-ruler-scroll {
+  .timeline-editor .tl-track-header {
+    padding: 5px !important;
+  }
+
+  .timeline-editor .tl-track-header button {
+    min-width: 24px;
+    min-height: 24px;
+    padding: 2px 4px !important;
+  }
+
+  .timeline-editor .tl-right {
+    min-width: 0 !important;
+    overflow: hidden !important;
+  }
+
+  .timeline-editor .tl-canvas-scroll {
     min-width: 0 !important;
     overflow-x: auto !important;
     overflow-y: auto !important;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior: contain;
+    touch-action: pan-x pan-y;
+  }
+
+  .timeline-editor .tl-ruler {
+    touch-action: pan-x;
+  }
+
+  .timeline-editor .tl-clip {
+    min-height: 40px !important;
+    touch-action: none;
   }
 
   .timeline-editor .tl-inspector {
@@ -265,14 +312,26 @@
     inset: auto 0 64px 0 !important;
     z-index: 1300 !important;
     width: 100% !important;
+    min-width: 0 !important;
     max-width: none !important;
     max-height: min(68dvh, 620px);
+    padding: 14px 14px calc(18px + env(safe-area-inset-bottom)) !important;
     border: 1px solid var(--daw-border, #394550);
     border-radius: 16px 16px 0 0;
     box-shadow: 0 -18px 45px rgba(0, 0, 0, .62);
     overflow-y: auto;
     transform: translateY(calc(100% + 80px));
     transition: transform .22s ease;
+  }
+
+  .timeline-editor .tl-inspector::before {
+    content: '';
+    display: block;
+    width: 42px;
+    height: 4px;
+    margin: -5px auto 12px;
+    border-radius: 999px;
+    background: #65717c;
   }
 
   .timeline-editor .tl-inspector.inspector-open {
@@ -321,5 +380,127 @@
   .mobile-action-bar .mobile-action-icon {
     font-size: 1.25rem;
     line-height: 1;
+  }
+
+  .mobile-track-picker {
+    position: fixed;
+    inset: auto 0 0 0;
+    z-index: 1400;
+    display: block;
+    max-height: min(78dvh, 700px);
+    padding: 8px 12px calc(16px + env(safe-area-inset-bottom));
+    border: 1px solid var(--daw-border, #394550);
+    border-radius: 18px 18px 0 0;
+    background: #182028;
+    box-shadow: 0 -22px 55px rgba(0, 0, 0, .72);
+    overflow-y: auto;
+    transform: translateY(105%);
+    transition: transform .22s ease;
+  }
+
+  .mobile-track-picker.open {
+    transform: translateY(0);
+  }
+
+  .mobile-sheet-handle {
+    width: 44px;
+    height: 4px;
+    margin: 2px auto 12px;
+    border-radius: 999px;
+    background: #65717c;
+  }
+
+  .mobile-sheet-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .mobile-sheet-heading strong {
+    display: block;
+    color: #fff;
+    font-size: 1rem;
+  }
+
+  .mobile-sheet-heading span {
+    display: block;
+    margin-top: 2px;
+    color: #8f9ca7;
+    font-size: .75rem;
+  }
+
+  .mobile-sheet-close {
+    min-width: 44px;
+    min-height: 44px;
+    border: 1px solid #3a4651;
+    border-radius: 9px;
+    background: #222b34;
+    color: #fff;
+  }
+
+  .mobile-track-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .mobile-track-option {
+    display: grid;
+    grid-template-columns: 38px minmax(0, 1fr);
+    align-items: center;
+    gap: 8px;
+    min-height: 72px;
+    padding: 9px;
+    border: 1px solid #394550;
+    border-radius: 11px;
+    background: #202a33;
+    color: #f3f6f8;
+    text-align: left;
+  }
+
+  .mobile-track-option:active,
+  .mobile-track-option:focus-visible {
+    border-color: var(--accent-color);
+    background: rgba(0, 255, 204, .1);
+    outline: none;
+  }
+
+  .mobile-track-icon {
+    display: grid;
+    place-items: center;
+    width: 38px;
+    height: 38px;
+    border-radius: 9px;
+    background: #111820;
+    font-size: 1.15rem;
+  }
+
+  .mobile-track-option strong,
+  .mobile-track-option small {
+    display: block;
+  }
+
+  .mobile-track-option strong {
+    font-size: .8rem;
+  }
+
+  .mobile-track-option small {
+    margin-top: 2px;
+    color: #8f9ca7;
+    font-size: .62rem;
+    line-height: 1.25;
+  }
+}
+
+@media (max-width: 380px) {
+  .transport-controls .panic {
+    min-width: 52px;
+    padding-inline: .3rem;
+  }
+
+  .mobile-track-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/css/studio-mobile.css
+++ b/css/studio-mobile.css
@@ -1,0 +1,325 @@
+/* Showduino Studio — mobile-first shell and timeline overrides */
+
+.mobile-menu-button,
+.mobile-sidebar-close,
+.mobile-action-bar,
+.mobile-sidebar-overlay {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  html,
+  body {
+    width: 100%;
+    min-height: 100%;
+    overflow: hidden;
+  }
+
+  body.mobile-drawer-open {
+    overflow: hidden;
+  }
+
+  .app-container {
+    display: block;
+    width: 100%;
+    min-height: 100dvh;
+    height: 100dvh;
+    overflow: hidden;
+  }
+
+  .sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 1200;
+    width: min(84vw, 320px);
+    max-height: none;
+    border-right: 1px solid var(--border-color);
+    border-bottom: 0;
+    box-shadow: 18px 0 40px rgba(0, 0, 0, .55);
+    transform: translateX(-105%);
+    transition: transform .22s ease;
+    overflow-y: auto;
+  }
+
+  .sidebar.sidebar-open {
+    transform: translateX(0);
+  }
+
+  .sidebar-header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    min-height: 64px;
+    background: var(--panel-bg);
+  }
+
+  .sidebar-header .logo {
+    margin: 0;
+    text-align: left;
+  }
+
+  .mobile-sidebar-close,
+  .mobile-menu-button {
+    display: inline-grid;
+    place-items: center;
+    min-width: 44px;
+    min-height: 44px;
+    border: 1px solid var(--border-color);
+    border-radius: 7px;
+    background: #20262d;
+    color: var(--text-color);
+    font-size: 1.25rem;
+    cursor: pointer;
+  }
+
+  .mobile-sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: block;
+    background: rgba(0, 0, 0, .66);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity .2s ease, visibility .2s ease;
+  }
+
+  .mobile-sidebar-overlay.active {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .sidebar-nav li {
+    min-height: 52px;
+    display: flex;
+    align-items: center;
+    padding: .8rem 1rem;
+  }
+
+  .main-content {
+    width: 100%;
+    height: 100dvh;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .top-bar {
+    position: sticky;
+    top: 0;
+    z-index: 900;
+    display: grid;
+    grid-template-columns: 44px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: .5rem;
+    padding: max(.45rem, env(safe-area-inset-top)) .6rem .45rem;
+    background: #20252b;
+  }
+
+  .top-bar > div {
+    width: auto;
+    min-width: 0;
+  }
+
+  .top-bar > div:first-of-type,
+  .studio-project-actions,
+  .top-bar > .system-info {
+    display: none !important;
+  }
+
+  .show-info {
+    grid-column: 2;
+    justify-content: flex-start !important;
+    min-width: 0;
+  }
+
+  .show-info .show-name {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 700;
+  }
+
+  .show-info .save-icon {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .transport-controls {
+    grid-column: 3;
+    flex-wrap: nowrap;
+    justify-content: flex-end !important;
+    gap: .3rem;
+  }
+
+  .transport-controls button {
+    min-width: 44px;
+    min-height: 44px;
+    padding: .45rem;
+    border-radius: 7px;
+  }
+
+  .transport-controls button:not(.panic):nth-child(n+3) {
+    display: none;
+  }
+
+  .transport-controls .panic {
+    min-width: 60px;
+    font-size: .72rem;
+    font-weight: 800;
+  }
+
+  .workspace {
+    height: calc(100dvh - 62px - 64px - env(safe-area-inset-bottom));
+    min-height: 0;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .workspace > .timeline-editor {
+    height: 100% !important;
+    min-height: 0 !important;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  .timeline-editor .tl-toolbar {
+    flex: 0 0 auto;
+    display: flex !important;
+    flex-wrap: nowrap !important;
+    gap: 6px;
+    width: 100%;
+    padding: 7px !important;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .timeline-editor .tl-toolbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .timeline-editor .tl-toolbar > *,
+  .timeline-editor .btn-toolbar {
+    flex: 0 0 auto;
+  }
+
+  .timeline-editor .btn-toolbar {
+    min-width: 44px;
+    min-height: 44px;
+    padding: .55rem .65rem;
+  }
+
+  .timeline-editor .daw-shortcuts {
+    display: none;
+  }
+
+  .timeline-editor .tl-main,
+  .timeline-editor .tl-body,
+  .timeline-editor .tl-workspace {
+    min-width: 0 !important;
+    min-height: 0 !important;
+    overflow: hidden !important;
+  }
+
+  .timeline-editor .tl-left {
+    width: 104px !important;
+    min-width: 104px !important;
+    max-width: 104px !important;
+    z-index: 4;
+  }
+
+  .timeline-editor .daw-library {
+    display: none !important;
+  }
+
+  .timeline-editor .tl-track-header,
+  .timeline-editor .tl-track-list-header {
+    min-width: 104px !important;
+  }
+
+  .timeline-editor .tl-track-header,
+  .timeline-editor .tl-track-row {
+    min-height: 56px !important;
+  }
+
+  .timeline-editor .tl-scroll,
+  .timeline-editor .tl-center,
+  .timeline-editor .tl-timeline,
+  .timeline-editor .tl-ruler-scroll {
+    min-width: 0 !important;
+    overflow-x: auto !important;
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+
+  .timeline-editor .tl-inspector {
+    position: fixed !important;
+    inset: auto 0 64px 0 !important;
+    z-index: 1300 !important;
+    width: 100% !important;
+    max-width: none !important;
+    max-height: min(68dvh, 620px);
+    border: 1px solid var(--daw-border, #394550);
+    border-radius: 16px 16px 0 0;
+    box-shadow: 0 -18px 45px rgba(0, 0, 0, .62);
+    overflow-y: auto;
+    transform: translateY(calc(100% + 80px));
+    transition: transform .22s ease;
+  }
+
+  .timeline-editor .tl-inspector.inspector-open {
+    transform: translateY(0);
+  }
+
+  .bottom-dock {
+    display: none !important;
+  }
+
+  .mobile-action-bar {
+    position: fixed;
+    inset: auto 0 0 0;
+    z-index: 1000;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    min-height: calc(64px + env(safe-area-inset-bottom));
+    padding: 6px 6px calc(6px + env(safe-area-inset-bottom));
+    border-top: 1px solid var(--border-color);
+    background: rgba(25, 31, 37, .98);
+    backdrop-filter: blur(12px);
+  }
+
+  .mobile-action-bar button {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    min-width: 0;
+    min-height: 50px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: #c7d0d8;
+    font-size: .68rem;
+    cursor: pointer;
+  }
+
+  .mobile-action-bar button:active,
+  .mobile-action-bar button.active {
+    background: rgba(0, 255, 204, .12);
+    color: var(--accent-color);
+  }
+
+  .mobile-action-bar .mobile-action-icon {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+}

--- a/js/studio-mobile-touch.js
+++ b/js/studio-mobile-touch.js
@@ -1,0 +1,341 @@
+// Showduino Studio mobile clip manipulation.
+// Adds touch-first drag, resize and long-press actions without changing the timeline data model.
+(function () {
+  'use strict';
+
+  const MOBILE_BREAKPOINT = 768;
+  const EDGE_SIZE_PX = 20;
+  const MOVE_THRESHOLD_PX = 7;
+  const LONG_PRESS_MS = 560;
+  const MIN_CLIP_MS = 100;
+
+  let gesture = null;
+  let longPressTimer = null;
+  let suppressClickUntil = 0;
+
+  function isMobile() {
+    return window.innerWidth < MOBILE_BREAKPOINT;
+  }
+
+  function editor() {
+    return window.timelineEditor || null;
+  }
+
+  function clips(ed) {
+    if (!ed) return [];
+    if (typeof ed._clips === 'function') return ed._clips();
+    return ed._state?.project?.clips || [];
+  }
+
+  function tracks(ed) {
+    if (!ed) return [];
+    const list = typeof ed._tracks === 'function' ? ed._tracks() : (ed._state?.project?.tracks || []);
+    return list.slice().sort((a, b) => (a.order || 0) - (b.order || 0));
+  }
+
+  function snapshot(ed) {
+    const project = ed?._state?.project;
+    if (!project || !Array.isArray(ed._undoStack)) return;
+    try {
+      ed._undoStack.push(JSON.parse(JSON.stringify(project)));
+      if (ed._undoStack.length > 60) ed._undoStack.shift();
+      if (Array.isArray(ed._redoStack)) ed._redoStack.length = 0;
+    } catch (_) {
+      // Undo support is best-effort; editing still continues if cloning fails.
+    }
+  }
+
+  function snapMs(ed, value) {
+    const safe = Math.max(0, value);
+    if (ed?._snapEnabled && typeof ed._snapValue === 'function') return Math.max(0, ed._snapValue(safe));
+    return safe;
+  }
+
+  function pxToMs(ed, px) {
+    const scale = Number(ed?._pxPerMs) || 0.1;
+    return px / scale;
+  }
+
+  function refresh(ed) {
+    if (!ed) return;
+    if (typeof ed._updateAllClips === 'function') ed._updateAllClips();
+    if (typeof ed._renderInspector === 'function') ed._renderInspector();
+    if (typeof ed._updateInspector === 'function') ed._updateInspector();
+    if (typeof ed._syncPlayheadPosition === 'function') ed._syncPlayheadPosition();
+  }
+
+  function selectClip(ed, clipId, clipEl) {
+    if (!ed || !clipId) return;
+    ed._selectedClipId = clipId;
+    refresh(ed);
+    clipEl?.classList.add('mobile-clip-selected');
+  }
+
+  function announce(message) {
+    let region = document.getElementById('mobile-studio-announcer');
+    if (!region) {
+      region = document.createElement('div');
+      region.id = 'mobile-studio-announcer';
+      region.className = 'sr-only';
+      region.setAttribute('aria-live', 'polite');
+      document.body.appendChild(region);
+    }
+    region.textContent = '';
+    window.setTimeout(() => { region.textContent = message; }, 20);
+  }
+
+  function makeId() {
+    if (window.crypto?.randomUUID) return window.crypto.randomUUID();
+    return `clip-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
+
+  function closeActions() {
+    const sheet = document.getElementById('mobile-clip-actions');
+    sheet?.classList.remove('open');
+    sheet?.setAttribute('aria-hidden', 'true');
+  }
+
+  function ensureActions() {
+    let sheet = document.getElementById('mobile-clip-actions');
+    if (sheet) return sheet;
+
+    sheet = document.createElement('section');
+    sheet.id = 'mobile-clip-actions';
+    sheet.className = 'mobile-clip-actions';
+    sheet.setAttribute('aria-hidden', 'true');
+    sheet.innerHTML = `
+      <div class="mobile-sheet-handle" aria-hidden="true"></div>
+      <div class="mobile-clip-actions-title">
+        <div><strong>Clip actions</strong><span id="mobile-clip-actions-name">Selected clip</span></div>
+        <button type="button" class="mobile-sheet-close" data-action="close" aria-label="Close clip actions">✕</button>
+      </div>
+      <div class="mobile-clip-actions-grid">
+        <button type="button" data-action="inspect"><span>☷</span><strong>Inspect</strong></button>
+        <button type="button" data-action="duplicate"><span>⧉</span><strong>Duplicate</strong></button>
+        <button type="button" data-action="delete" class="danger"><span>🗑</span><strong>Delete</strong></button>
+      </div>`;
+
+    document.body.appendChild(sheet);
+    sheet.addEventListener('click', (event) => {
+      const button = event.target.closest('[data-action]');
+      if (!button) return;
+      const action = button.dataset.action;
+      const ed = editor();
+      const clipId = sheet.dataset.clipId;
+      const clip = clips(ed).find((item) => item.id === clipId);
+
+      if (action === 'close') {
+        closeActions();
+        return;
+      }
+      if (!ed || !clip) return;
+
+      if (action === 'inspect') {
+        selectClip(ed, clip.id);
+        closeActions();
+        window.ShowduinoMobile?.openInspector?.();
+        return;
+      }
+
+      if (action === 'duplicate') {
+        snapshot(ed);
+        const copy = JSON.parse(JSON.stringify(clip));
+        copy.id = makeId();
+        copy.startMs = snapMs(ed, Number(clip.startMs || 0) + Math.max(Number(ed._snapMs) || 250, 250));
+        copy.label = copy.label ? `${copy.label} copy` : 'Clip copy';
+        clips(ed).push(copy);
+        ed._selectedClipId = copy.id;
+        refresh(ed);
+        closeActions();
+        announce('Clip duplicated');
+        return;
+      }
+
+      if (action === 'delete') {
+        const name = clip.label || clip.type || 'clip';
+        if (!window.confirm(`Delete ${name}?`)) return;
+        snapshot(ed);
+        const list = clips(ed);
+        const index = list.findIndex((item) => item.id === clip.id);
+        if (index >= 0) list.splice(index, 1);
+        if (ed._selectedClipId === clip.id) ed._selectedClipId = null;
+        refresh(ed);
+        closeActions();
+        window.ShowduinoMobile?.closeInspector?.();
+        announce('Clip deleted');
+      }
+    });
+
+    return sheet;
+  }
+
+  function openActions(ed, clip, clipEl) {
+    if (!clip) return;
+    selectClip(ed, clip.id, clipEl);
+    window.ShowduinoMobile?.closeInspector?.();
+    const sheet = ensureActions();
+    sheet.dataset.clipId = clip.id;
+    const name = sheet.querySelector('#mobile-clip-actions-name');
+    if (name) name.textContent = clip.label || clip.type || 'Selected clip';
+    sheet.classList.add('open');
+    sheet.setAttribute('aria-hidden', 'false');
+    navigator.vibrate?.(20);
+  }
+
+  function clearLongPress() {
+    if (longPressTimer) window.clearTimeout(longPressTimer);
+    longPressTimer = null;
+  }
+
+  function locateTrack(ed, clientY) {
+    const canvas = document.querySelector('.tl-canvas');
+    const scroll = document.querySelector('.tl-canvas-scroll');
+    const ordered = tracks(ed);
+    if (!canvas || !ordered.length) return null;
+    const rect = canvas.getBoundingClientRect();
+    const y = clientY - rect.top + (scroll?.scrollTop || 0);
+    const rowHeight = Number(ed._trackHeight) || 60;
+    const index = Math.max(0, Math.min(ordered.length - 1, Math.floor(y / rowHeight)));
+    return ordered[index] || null;
+  }
+
+  function pointerDown(event) {
+    if (!isMobile() || event.pointerType === 'mouse' || event.button !== 0) return;
+    const clipEl = event.target.closest?.('.tl-clip');
+    if (!clipEl) return;
+
+    const ed = editor();
+    const clipId = clipEl.dataset.clipId;
+    const clip = clips(ed).find((item) => item.id === clipId);
+    if (!ed || !clip) return;
+
+    const track = tracks(ed).find((item) => item.id === clip.trackId);
+    if (track?.locked) return;
+
+    const rect = clipEl.getBoundingClientRect();
+    const localX = event.clientX - rect.left;
+    const mode = localX <= EDGE_SIZE_PX ? 'resize-left' : (localX >= rect.width - EDGE_SIZE_PX ? 'resize-right' : 'move');
+
+    gesture = {
+      pointerId: event.pointerId,
+      clipEl,
+      clip,
+      mode,
+      startX: event.clientX,
+      startY: event.clientY,
+      originalStartMs: Number(clip.startMs) || 0,
+      originalDurationMs: Math.max(MIN_CLIP_MS, Number(clip.durationMs) || MIN_CLIP_MS),
+      originalTrackId: clip.trackId,
+      active: false,
+      snapshotTaken: false
+    };
+
+    clipEl.setPointerCapture?.(event.pointerId);
+    clipEl.classList.add('mobile-clip-armed');
+    clearLongPress();
+    longPressTimer = window.setTimeout(() => {
+      if (!gesture || gesture.active) return;
+      gesture.longPressed = true;
+      openActions(ed, clip, clipEl);
+    }, LONG_PRESS_MS);
+  }
+
+  function pointerMove(event) {
+    if (!gesture || event.pointerId !== gesture.pointerId) return;
+    const ed = editor();
+    if (!ed) return;
+
+    const dx = event.clientX - gesture.startX;
+    const dy = event.clientY - gesture.startY;
+    const distance = Math.hypot(dx, dy);
+
+    if (!gesture.active) {
+      if (distance < MOVE_THRESHOLD_PX || gesture.longPressed) return;
+      gesture.active = true;
+      clearLongPress();
+      if (!gesture.snapshotTaken) {
+        snapshot(ed);
+        gesture.snapshotTaken = true;
+      }
+      gesture.clipEl.classList.remove('mobile-clip-armed');
+      gesture.clipEl.classList.add('mobile-clip-manipulating');
+      document.body.classList.add('mobile-clip-gesture');
+      window.ShowduinoMobile?.closeInspector?.();
+    }
+
+    event.preventDefault();
+    const deltaMs = pxToMs(ed, dx);
+    const minDuration = Math.max(MIN_CLIP_MS, Number(ed._snapMs) || MIN_CLIP_MS);
+
+    if (gesture.mode === 'move') {
+      gesture.clip.startMs = snapMs(ed, gesture.originalStartMs + deltaMs);
+      const targetTrack = locateTrack(ed, event.clientY);
+      if (targetTrack && !targetTrack.locked) gesture.clip.trackId = targetTrack.id;
+    } else if (gesture.mode === 'resize-left') {
+      const endMs = gesture.originalStartMs + gesture.originalDurationMs;
+      const nextStart = Math.min(endMs - minDuration, snapMs(ed, gesture.originalStartMs + deltaMs));
+      gesture.clip.startMs = Math.max(0, nextStart);
+      gesture.clip.durationMs = Math.max(minDuration, endMs - gesture.clip.startMs);
+    } else {
+      gesture.clip.durationMs = Math.max(minDuration, snapMs(ed, gesture.originalDurationMs + deltaMs));
+    }
+
+    const left = (Number(gesture.clip.startMs) || 0) * (Number(ed._pxPerMs) || 0.1);
+    const width = Math.max(8, (Number(gesture.clip.durationMs) || minDuration) * (Number(ed._pxPerMs) || 0.1));
+    gesture.clipEl.style.left = `${left}px`;
+    gesture.clipEl.style.width = `${width}px`;
+
+    if (gesture.mode === 'move') {
+      const ordered = tracks(ed);
+      const index = ordered.findIndex((item) => item.id === gesture.clip.trackId);
+      if (index >= 0) gesture.clipEl.style.top = `${index * (Number(ed._trackHeight) || 60) + 8}px`;
+    }
+  }
+
+  function finishGesture(event, cancelled) {
+    if (!gesture || event.pointerId !== gesture.pointerId) return;
+    const ed = editor();
+    clearLongPress();
+    gesture.clipEl.releasePointerCapture?.(event.pointerId);
+    gesture.clipEl.classList.remove('mobile-clip-armed', 'mobile-clip-manipulating');
+    document.body.classList.remove('mobile-clip-gesture');
+
+    if (cancelled && gesture.active) {
+      gesture.clip.startMs = gesture.originalStartMs;
+      gesture.clip.durationMs = gesture.originalDurationMs;
+      gesture.clip.trackId = gesture.originalTrackId;
+    }
+
+    if (gesture.active) {
+      suppressClickUntil = Date.now() + 450;
+      selectClip(ed, gesture.clip.id);
+      refresh(ed);
+      announce(gesture.mode === 'move' ? 'Clip moved' : 'Clip resized');
+    } else if (!gesture.longPressed) {
+      selectClip(ed, gesture.clip.id, gesture.clipEl);
+      window.setTimeout(() => window.ShowduinoMobile?.openInspector?.(), 0);
+    }
+
+    gesture = null;
+  }
+
+  function interceptClick(event) {
+    if (Date.now() < suppressClickUntil && event.target.closest?.('.tl-clip')) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+
+  document.addEventListener('pointerdown', pointerDown, true);
+  document.addEventListener('pointermove', pointerMove, { capture: true, passive: false });
+  document.addEventListener('pointerup', (event) => finishGesture(event, false), true);
+  document.addEventListener('pointercancel', (event) => finishGesture(event, true), true);
+  document.addEventListener('click', interceptClick, true);
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') closeActions();
+  });
+
+  window.ShowduinoMobileTouch = {
+    closeActions
+  };
+}());

--- a/js/studio-mobile.js
+++ b/js/studio-mobile.js
@@ -1,0 +1,139 @@
+// Showduino Studio mobile interaction layer.
+// Keeps the existing desktop editor intact while exposing phone-friendly drawers.
+(function () {
+  'use strict';
+
+  const MOBILE_BREAKPOINT = 768;
+
+  function isMobile() {
+    return window.innerWidth < MOBILE_BREAKPOINT;
+  }
+
+  function getSidebar() {
+    return document.getElementById('studio-sidebar');
+  }
+
+  function getOverlay() {
+    return document.getElementById('mobile-sidebar-overlay');
+  }
+
+  function setSidebar(open) {
+    const sidebar = getSidebar();
+    const overlay = getOverlay();
+    const menuButton = document.getElementById('mobile-menu-button');
+
+    if (!sidebar) return;
+
+    sidebar.classList.toggle('sidebar-open', open);
+    sidebar.setAttribute('aria-hidden', open ? 'false' : String(isMobile()));
+    overlay?.classList.toggle('active', open);
+    overlay?.setAttribute('aria-hidden', open ? 'false' : 'true');
+    menuButton?.setAttribute('aria-expanded', open ? 'true' : 'false');
+    document.body.classList.toggle('mobile-drawer-open', open);
+  }
+
+  function closeInspector() {
+    const inspector = document.querySelector('.tl-inspector');
+    inspector?.classList.remove('inspector-open');
+  }
+
+  function openInspector() {
+    const inspector = document.querySelector('.tl-inspector');
+    if (!inspector) return;
+    inspector.classList.add('inspector-open');
+  }
+
+  function toggleLibrary() {
+    const library = document.querySelector('.daw-library');
+    if (!library) return;
+
+    // On mobile the library is temporarily promoted to an overlay panel.
+    const isOpen = library.classList.toggle('mobile-library-open');
+    if (isOpen) {
+      library.style.setProperty('display', 'block', 'important');
+      library.style.position = 'fixed';
+      library.style.left = '8px';
+      library.style.right = '8px';
+      library.style.bottom = '72px';
+      library.style.zIndex = '1300';
+      library.style.maxHeight = '68dvh';
+      library.style.overflow = 'auto';
+      library.style.border = '1px solid var(--daw-border, #394550)';
+      library.style.borderRadius = '14px';
+      library.style.boxShadow = '0 18px 45px rgba(0,0,0,.65)';
+    } else {
+      library.removeAttribute('style');
+    }
+  }
+
+  function addTrack() {
+    // Reuse the existing first visible Add Track control rather than duplicate editor logic.
+    const button = Array.from(document.querySelectorAll('.timeline-editor button')).find((candidate) =>
+      /add\s*track/i.test(candidate.textContent || '')
+    );
+    button?.click();
+  }
+
+  function openMore() {
+    // The toolbar remains horizontally scrollable. Move it to the end to reveal secondary tools.
+    const toolbar = document.querySelector('.timeline-editor .tl-toolbar');
+    if (!toolbar) return;
+    toolbar.scrollTo({ left: toolbar.scrollWidth, behavior: 'smooth' });
+  }
+
+  function bindMobileControls() {
+    document.getElementById('mobile-menu-button')?.addEventListener('click', () => setSidebar(true));
+    document.getElementById('mobile-sidebar-close')?.addEventListener('click', () => setSidebar(false));
+    getOverlay()?.addEventListener('click', () => setSidebar(false));
+
+    document.querySelectorAll('.sidebar-nav li').forEach((item) => {
+      item.addEventListener('click', () => {
+        if (isMobile()) setSidebar(false);
+      });
+    });
+
+    document.getElementById('mobile-add-track')?.addEventListener('click', addTrack);
+    document.getElementById('mobile-library')?.addEventListener('click', toggleLibrary);
+    document.getElementById('mobile-inspector')?.addEventListener('click', () => {
+      const inspector = document.querySelector('.tl-inspector');
+      if (!inspector) return;
+      inspector.classList.contains('inspector-open') ? closeInspector() : openInspector();
+    });
+    document.getElementById('mobile-more')?.addEventListener('click', openMore);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key !== 'Escape') return;
+      setSidebar(false);
+      closeInspector();
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!isMobile()) return;
+      const clip = event.target.closest?.('.tl-clip');
+      if (clip) {
+        window.setTimeout(openInspector, 0);
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      if (!isMobile()) {
+        setSidebar(false);
+        closeInspector();
+        const library = document.querySelector('.daw-library.mobile-library-open');
+        if (library) {
+          library.classList.remove('mobile-library-open');
+          library.removeAttribute('style');
+        }
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', bindMobileControls);
+
+  window.ShowduinoMobile = {
+    openSidebar: () => setSidebar(true),
+    closeSidebar: () => setSidebar(false),
+    openInspector,
+    closeInspector
+  };
+}());

--- a/js/studio-mobile.js
+++ b/js/studio-mobile.js
@@ -1,9 +1,19 @@
 // Showduino Studio mobile interaction layer.
-// Keeps the existing desktop editor intact while exposing phone-friendly drawers.
+// Keeps the existing desktop editor intact while exposing phone-friendly controls.
 (function () {
   'use strict';
 
   const MOBILE_BREAKPOINT = 768;
+  const TRACK_TYPES = [
+    { type: 'audio', icon: '🎵', label: 'Audio', detail: 'Music, ambience and sound cues' },
+    { type: 'fx', icon: '✨', label: 'FX', detail: 'Reusable effects and compound actions' },
+    { type: 'lighting', icon: '💡', label: 'Lighting', detail: 'Lighting scenes and fades' },
+    { type: 'pixel', icon: '🌈', label: 'Pixel', detail: 'Addressable pixel effects' },
+    { type: 'relay', icon: '⚡', label: 'Relay', detail: 'Timed relay and output actions' },
+    { type: 'dmx', icon: '🎛', label: 'DMX', detail: 'DMX fixtures and channel scenes' },
+    { type: 'prop', icon: '⚙️', label: 'Prop', detail: 'Show prop actions' },
+    { type: 'trigger', icon: '🎯', label: 'Trigger', detail: 'External and logical triggers' }
+  ];
 
   function isMobile() {
     return window.innerWidth < MOBILE_BREAKPOINT;
@@ -21,7 +31,6 @@
     const sidebar = getSidebar();
     const overlay = getOverlay();
     const menuButton = document.getElementById('mobile-menu-button');
-
     if (!sidebar) return;
 
     sidebar.classList.toggle('sidebar-open', open);
@@ -33,52 +42,165 @@
   }
 
   function closeInspector() {
-    const inspector = document.querySelector('.tl-inspector');
-    inspector?.classList.remove('inspector-open');
+    document.querySelector('.tl-inspector')?.classList.remove('inspector-open');
+    document.getElementById('mobile-inspector')?.classList.remove('active');
   }
 
   function openInspector() {
     const inspector = document.querySelector('.tl-inspector');
     if (!inspector) return;
+    closeLibrary();
+    closeTrackPicker();
     inspector.classList.add('inspector-open');
+    document.getElementById('mobile-inspector')?.classList.add('active');
+  }
+
+  function closeLibrary() {
+    const library = document.querySelector('.daw-library.mobile-library-open');
+    if (!library) return;
+    library.classList.remove('mobile-library-open');
+    library.removeAttribute('style');
+    document.getElementById('mobile-library')?.classList.remove('active');
   }
 
   function toggleLibrary() {
     const library = document.querySelector('.daw-library');
     if (!library) return;
 
-    // On mobile the library is temporarily promoted to an overlay panel.
-    const isOpen = library.classList.toggle('mobile-library-open');
-    if (isOpen) {
-      library.style.setProperty('display', 'block', 'important');
-      library.style.position = 'fixed';
-      library.style.left = '8px';
-      library.style.right = '8px';
-      library.style.bottom = '72px';
-      library.style.zIndex = '1300';
-      library.style.maxHeight = '68dvh';
-      library.style.overflow = 'auto';
-      library.style.border = '1px solid var(--daw-border, #394550)';
-      library.style.borderRadius = '14px';
-      library.style.boxShadow = '0 18px 45px rgba(0,0,0,.65)';
-    } else {
-      library.removeAttribute('style');
+    const opening = !library.classList.contains('mobile-library-open');
+    closeInspector();
+    closeTrackPicker();
+
+    if (!opening) {
+      closeLibrary();
+      return;
     }
+
+    library.classList.add('mobile-library-open');
+    document.getElementById('mobile-library')?.classList.add('active');
+    library.style.setProperty('display', 'block', 'important');
+    library.style.position = 'fixed';
+    library.style.left = '8px';
+    library.style.right = '8px';
+    library.style.bottom = '72px';
+    library.style.zIndex = '1300';
+    library.style.maxHeight = '68dvh';
+    library.style.overflow = 'auto';
+    library.style.border = '1px solid var(--daw-border, #394550)';
+    library.style.borderRadius = '14px';
+    library.style.boxShadow = '0 18px 45px rgba(0,0,0,.65)';
   }
 
-  function addTrack() {
-    // Reuse the existing first visible Add Track control rather than duplicate editor logic.
-    const button = Array.from(document.querySelectorAll('.timeline-editor button')).find((candidate) =>
-      /add\s*track/i.test(candidate.textContent || '')
-    );
-    button?.click();
+  function ensureTrackPicker() {
+    let sheet = document.getElementById('mobile-track-picker');
+    if (sheet) return sheet;
+
+    sheet = document.createElement('section');
+    sheet.id = 'mobile-track-picker';
+    sheet.className = 'mobile-track-picker';
+    sheet.setAttribute('aria-hidden', 'true');
+    sheet.setAttribute('aria-label', 'Add track');
+
+    sheet.innerHTML = `
+      <div class="mobile-sheet-handle" aria-hidden="true"></div>
+      <div class="mobile-sheet-heading">
+        <div>
+          <strong>Add a track</strong>
+          <span>Choose what this timeline lane controls</span>
+        </div>
+        <button type="button" class="mobile-sheet-close" aria-label="Close track picker">✕</button>
+      </div>
+      <div class="mobile-track-grid">
+        ${TRACK_TYPES.map((item) => `
+          <button type="button" class="mobile-track-option" data-track-type="${item.type}">
+            <span class="mobile-track-icon">${item.icon}</span>
+            <span><strong>${item.label}</strong><small>${item.detail}</small></span>
+          </button>
+        `).join('')}
+      </div>`;
+
+    document.body.appendChild(sheet);
+    sheet.querySelector('.mobile-sheet-close')?.addEventListener('click', closeTrackPicker);
+    sheet.querySelectorAll('[data-track-type]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const type = button.dataset.trackType;
+        if (window.timelineEditor && typeof window.timelineEditor.addTrack === 'function') {
+          window.timelineEditor.addTrack(type);
+          closeTrackPicker();
+          announce(`${button.querySelector('strong')?.textContent || type} track added`);
+        }
+      });
+    });
+    return sheet;
+  }
+
+  function openTrackPicker() {
+    closeInspector();
+    closeLibrary();
+    const sheet = ensureTrackPicker();
+    sheet.classList.add('open');
+    sheet.setAttribute('aria-hidden', 'false');
+    document.getElementById('mobile-add-track')?.classList.add('active');
+    sheet.querySelector('[data-track-type]')?.focus({ preventScroll: true });
+  }
+
+  function closeTrackPicker() {
+    const sheet = document.getElementById('mobile-track-picker');
+    sheet?.classList.remove('open');
+    sheet?.setAttribute('aria-hidden', 'true');
+    document.getElementById('mobile-add-track')?.classList.remove('active');
   }
 
   function openMore() {
-    // The toolbar remains horizontally scrollable. Move it to the end to reveal secondary tools.
     const toolbar = document.querySelector('.timeline-editor .tl-toolbar');
     if (!toolbar) return;
+    closeInspector();
+    closeLibrary();
+    closeTrackPicker();
     toolbar.scrollTo({ left: toolbar.scrollWidth, behavior: 'smooth' });
+  }
+
+  function announce(message) {
+    let region = document.getElementById('mobile-studio-announcer');
+    if (!region) {
+      region = document.createElement('div');
+      region.id = 'mobile-studio-announcer';
+      region.className = 'sr-only';
+      region.setAttribute('aria-live', 'polite');
+      document.body.appendChild(region);
+    }
+    region.textContent = '';
+    window.setTimeout(() => { region.textContent = message; }, 20);
+  }
+
+  function coordinateTimelineScroll() {
+    const canvasScroll = document.querySelector('.tl-canvas-scroll');
+    const trackList = document.querySelector('.tl-track-list');
+    if (!canvasScroll || !trackList || canvasScroll.dataset.mobileSyncBound === 'true') return;
+
+    canvasScroll.dataset.mobileSyncBound = 'true';
+    let syncing = false;
+    canvasScroll.addEventListener('scroll', () => {
+      if (!isMobile() || syncing) return;
+      syncing = true;
+      trackList.scrollTop = canvasScroll.scrollTop;
+      syncing = false;
+    }, { passive: true });
+
+    trackList.addEventListener('scroll', () => {
+      if (!isMobile() || syncing) return;
+      syncing = true;
+      canvasScroll.scrollTop = trackList.scrollTop;
+      syncing = false;
+    }, { passive: true });
+  }
+
+  function observeTimeline() {
+    const workspace = document.querySelector('.workspace');
+    if (!workspace) return;
+    const observer = new MutationObserver(() => coordinateTimelineScroll());
+    observer.observe(workspace, { childList: true, subtree: true });
+    coordinateTimelineScroll();
   }
 
   function bindMobileControls() {
@@ -92,7 +214,7 @@
       });
     });
 
-    document.getElementById('mobile-add-track')?.addEventListener('click', addTrack);
+    document.getElementById('mobile-add-track')?.addEventListener('click', openTrackPicker);
     document.getElementById('mobile-library')?.addEventListener('click', toggleLibrary);
     document.getElementById('mobile-inspector')?.addEventListener('click', () => {
       const inspector = document.querySelector('.tl-inspector');
@@ -105,27 +227,27 @@
       if (event.key !== 'Escape') return;
       setSidebar(false);
       closeInspector();
+      closeLibrary();
+      closeTrackPicker();
     });
 
     document.addEventListener('click', (event) => {
       if (!isMobile()) return;
       const clip = event.target.closest?.('.tl-clip');
-      if (clip) {
-        window.setTimeout(openInspector, 0);
-      }
+      if (clip) window.setTimeout(openInspector, 0);
     });
 
     window.addEventListener('resize', () => {
       if (!isMobile()) {
         setSidebar(false);
         closeInspector();
-        const library = document.querySelector('.daw-library.mobile-library-open');
-        if (library) {
-          library.classList.remove('mobile-library-open');
-          library.removeAttribute('style');
-        }
+        closeLibrary();
+        closeTrackPicker();
       }
+      coordinateTimelineScroll();
     });
+
+    observeTimeline();
   }
 
   document.addEventListener('DOMContentLoaded', bindMobileControls);
@@ -134,6 +256,9 @@
     openSidebar: () => setSidebar(true),
     closeSidebar: () => setSidebar(false),
     openInspector,
-    closeInspector
+    closeInspector,
+    openTrackPicker,
+    closeTrackPicker,
+    closeLibrary
   };
 }());

--- a/studio.html
+++ b/studio.html
@@ -2,13 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
     <meta name="description" content="Build, control, save and export immersive show projects with Showduino Studio.">
     <title>Showduino Studio</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="css/studio-daw.css">
     <link rel="stylesheet" href="css/studio-inspector.css">
     <link rel="stylesheet" href="css/studio-timeline-mixer.css">
+    <link rel="stylesheet" href="css/studio-mobile.css">
     <style>
         .studio-project-actions { display:flex; gap:.35rem; flex-wrap:wrap; align-items:center; }
         .studio-action-btn { min-height:36px; padding:.45rem .7rem; border:1px solid var(--border-color); border-radius:5px; background:#333; color:var(--text-color); cursor:pointer; text-decoration:none; }
@@ -20,8 +21,11 @@
 </head>
 <body>
     <div class="app-container">
-        <aside class="sidebar">
-            <div class="sidebar-header"><h1 class="logo">Showduino Studio</h1></div>
+        <aside id="studio-sidebar" class="sidebar" aria-label="Studio navigation drawer">
+            <div class="sidebar-header">
+                <h1 class="logo">Showduino Studio</h1>
+                <button id="mobile-sidebar-close" class="mobile-sidebar-close" type="button" aria-label="Close navigation">×</button>
+            </div>
             <nav class="sidebar-nav" aria-label="Studio navigation">
                 <ul>
                     <li class="active" data-panel="introduction" tabindex="0">Introduction</li>
@@ -38,8 +42,12 @@
                 </ul>
             </nav>
         </aside>
+
+        <div id="mobile-sidebar-overlay" class="mobile-sidebar-overlay" aria-hidden="true"></div>
+
         <main class="main-content">
             <header class="top-bar">
+                <button id="mobile-menu-button" class="mobile-menu-button" type="button" aria-label="Open navigation" aria-controls="studio-sidebar" aria-expanded="false">☰</button>
                 <div style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;">
                     <a href="index.html" class="back-to-menu-btn">← Website</a>
                     <a href="account.html" class="back-to-menu-btn">Account</a>
@@ -64,6 +72,7 @@
             </header>
             <div class="workspace"><!-- Panels are loaded by app.js. --></div>
         </main>
+
         <footer class="bottom-dock collapsed">
             <div class="terminal">
                 <div class="terminal-header">
@@ -78,7 +87,15 @@
                 <div class="terminal-output" aria-live="polite"></div>
             </div>
         </footer>
+
+        <nav class="mobile-action-bar" aria-label="Timeline mobile actions">
+            <button id="mobile-add-track" type="button"><span class="mobile-action-icon">＋</span><span>Add</span></button>
+            <button id="mobile-library" type="button"><span class="mobile-action-icon">▦</span><span>Library</span></button>
+            <button id="mobile-inspector" type="button"><span class="mobile-action-icon">⌁</span><span>Inspector</span></button>
+            <button id="mobile-more" type="button"><span class="mobile-action-icon">•••</span><span>More</span></button>
+        </nav>
     </div>
+
     <script src="config/runtime-config.js"></script>
     <script src="js/cloud/firebase-service.js"></script>
     <script src="js/api.js"></script>
@@ -94,6 +111,7 @@
     <script src="js/panels.js"></script>
     <script src="app.js"></script>
     <script src="js/studio-projects.js"></script>
+    <script src="js/studio-mobile.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', async () => {
             window.connectionDetector = new window.ConnectionDetector();

--- a/studio.html
+++ b/studio.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="css/studio-inspector.css">
     <link rel="stylesheet" href="css/studio-timeline-mixer.css">
     <link rel="stylesheet" href="css/studio-mobile.css">
+    <link rel="stylesheet" href="css/studio-mobile-touch.css">
     <style>
         .studio-project-actions { display:flex; gap:.35rem; flex-wrap:wrap; align-items:center; }
         .studio-action-btn { min-height:36px; padding:.45rem .7rem; border:1px solid var(--border-color); border-radius:5px; background:#333; color:var(--text-color); cursor:pointer; text-decoration:none; }
@@ -107,6 +108,7 @@
     <script src="app.js"></script>
     <script src="js/studio-projects.js"></script>
     <script src="js/studio-mobile.js"></script>
+    <script src="js/studio-mobile-touch.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', async () => {
             window.connectionDetector = new window.ConnectionDetector();

--- a/studio.html
+++ b/studio.html
@@ -21,10 +21,10 @@
 </head>
 <body>
     <div class="app-container">
-        <aside id="studio-sidebar" class="sidebar" aria-label="Studio navigation drawer">
+        <aside class="sidebar" id="studio-sidebar" aria-label="Studio navigation">
             <div class="sidebar-header">
                 <h1 class="logo">Showduino Studio</h1>
-                <button id="mobile-sidebar-close" class="mobile-sidebar-close" type="button" aria-label="Close navigation">×</button>
+                <button id="mobile-sidebar-close" class="mobile-sidebar-close" type="button" aria-label="Close navigation">✕</button>
             </div>
             <nav class="sidebar-nav" aria-label="Studio navigation">
                 <ul>
@@ -42,9 +42,7 @@
                 </ul>
             </nav>
         </aside>
-
         <div id="mobile-sidebar-overlay" class="mobile-sidebar-overlay" aria-hidden="true"></div>
-
         <main class="main-content">
             <header class="top-bar">
                 <button id="mobile-menu-button" class="mobile-menu-button" type="button" aria-label="Open navigation" aria-controls="studio-sidebar" aria-expanded="false">☰</button>
@@ -72,7 +70,6 @@
             </header>
             <div class="workspace"><!-- Panels are loaded by app.js. --></div>
         </main>
-
         <footer class="bottom-dock collapsed">
             <div class="terminal">
                 <div class="terminal-header">
@@ -87,15 +84,13 @@
                 <div class="terminal-output" aria-live="polite"></div>
             </div>
         </footer>
-
-        <nav class="mobile-action-bar" aria-label="Timeline mobile actions">
-            <button id="mobile-add-track" type="button"><span class="mobile-action-icon">＋</span><span>Add</span></button>
-            <button id="mobile-library" type="button"><span class="mobile-action-icon">▦</span><span>Library</span></button>
-            <button id="mobile-inspector" type="button"><span class="mobile-action-icon">⌁</span><span>Inspector</span></button>
-            <button id="mobile-more" type="button"><span class="mobile-action-icon">•••</span><span>More</span></button>
+        <nav class="mobile-action-bar" aria-label="Timeline tools">
+            <button id="mobile-add-track" type="button" aria-label="Add a track"><span class="mobile-action-icon">＋</span><span>Add</span></button>
+            <button id="mobile-library" type="button" aria-label="Open effects library" aria-expanded="false"><span class="mobile-action-icon">▦</span><span>Library</span></button>
+            <button id="mobile-inspector" type="button" aria-label="Open clip inspector" aria-expanded="false"><span class="mobile-action-icon">☷</span><span>Inspector</span></button>
+            <button id="mobile-more" type="button" aria-label="Show more timeline tools"><span class="mobile-action-icon">•••</span><span>More</span></button>
         </nav>
     </div>
-
     <script src="config/runtime-config.js"></script>
     <script src="js/cloud/firebase-service.js"></script>
     <script src="js/api.js"></script>


### PR DESCRIPTION
## Mobile-first Showduino Timeline Editor overhaul

This draft PR transforms Studio from a desktop DAW squeezed into a phone viewport into a dedicated mobile editing experience, while preserving the current timeline data model and desktop editor.

### Mobile shell
- Off-canvas Studio navigation drawer.
- Compact mobile app bar with show name, save, transport and panic controls.
- Full-width timeline workspace.
- Desktop terminal hidden on phones.
- Safe-area support for modern devices.

### Mobile editor controls
- Persistent bottom action bar for Add, Library, Inspector and More.
- Proper Add Track bottom sheet for Audio, FX, Lighting, Pixel, Relay, DMX, Prop and Trigger tracks.
- FX Library promoted to an on-demand mobile overlay.
- Inspector converted into a bottom sheet.
- Horizontally scrollable timeline toolbar.
- Synchronized vertical scrolling between track headers and lanes.
- Larger lanes, track buttons and touch targets.

### Touch clip editing
- Direct one-finger clip dragging along the timeline.
- Vertical dragging between compatible unlocked tracks.
- Left-edge and right-edge touch resizing.
- Existing snap settings respected during drag and resize.
- Timeline scrolling is suppressed only after a clip gesture passes the movement threshold.
- Tap selects a clip and opens Inspector.
- Long press opens Clip Actions.
- Clip Actions include Inspect, Duplicate and confirmed Delete.
- Undo snapshots are recorded before destructive or positional edits where the existing editor stack is available.
- Locked tracks reject mobile clip manipulation.
- Visual edge handles, selected state and active manipulation feedback.
- Screen-reader announcements for track and clip operations.

### New files
- `css/studio-mobile.css`
- `css/studio-mobile-touch.css`
- `js/studio-mobile.js`
- `js/studio-mobile-touch.js`

### Updated
- `studio.html`

### Remaining verification before ready-for-review
- Test real devices at 360px, 390px and 412px widths plus landscape.
- Confirm the current undo implementation accepts project snapshots in every editor state.
- Check touch interaction alongside any existing desktop mouse drag handlers.
- Validate audio and FX clip inspectors after mobile duplicate/delete operations.

The PR remains draft until those device-level checks are complete.