### PR TITLE
Make public Showduino Studio creator-focused

### DIFF
--- a/account.html
+++ b/account.html
@@ -23,15 +23,15 @@
     <section class="page-heading">
       <span class="badge">SHOWDUINO ID</span>
       <h1>Your account</h1>
-      <p>One account for Showduino Studio, HauntSync projects, registered hardware and future community features.</p>
+      <p>One account for Showduino Studio, cloud-saved productions and future connected Showduino features.</p>
     </section>
 
-    <div id="account-status" class="status-banner" role="status" aria-live="polite">Loading account services…</div>
+    <div id="account-status" class="status-banner" role="status" aria-live="polite">Loading Showduino account services…</div>
 
     <section id="auth-forms" class="grid two">
       <form id="login-form" class="card">
         <h2>Sign in</h2>
-        <p class="muted">Access your projects and connected devices.</p>
+        <p class="muted">Open shows you saved from any computer or phone.</p>
         <div class="form-group">
           <label for="login-email">Email address</label>
           <input id="login-email" class="form-control" type="email" autocomplete="email" required>
@@ -45,7 +45,7 @@
 
       <form id="register-form" class="card">
         <h2>Create an account</h2>
-        <p class="muted">Prepare your Showduino identity and cloud workspace.</p>
+        <p class="muted">Create your free Showduino ID and cloud workspace.</p>
         <div class="form-group">
           <label for="register-name">Display name</label>
           <input id="register-name" class="form-control" type="text" autocomplete="name" maxlength="60" required>
@@ -74,9 +74,9 @@
       </article>
 
       <article class="card">
-        <h2>Account status</h2>
-        <p class="muted">Your account is ready for project syncing, device ownership and profile features as each website service is enabled.</p>
-        <span class="badge">FREE ACCESS</span>
+        <h2>Cloud status</h2>
+        <p class="muted">Your shows are protected by your Showduino account. Only you can read, change or delete your private projects.</p>
+        <span class="badge">SUPABASE CONNECTED</span>
       </article>
     </section>
 
@@ -84,7 +84,7 @@
       <div class="button-row" style="justify-content: space-between;">
         <div>
           <h2 style="margin-bottom: .35rem;">Your projects</h2>
-          <p class="muted" style="margin: 0;">Local and cloud-linked show projects will be managed here.</p>
+          <p class="muted" style="margin: 0;">Cloud shows appear when you are signed in. Shows saved only on this device are also listed.</p>
         </div>
         <a class="btn secondary" href="studio.html">Create a show</a>
       </div>
@@ -97,7 +97,8 @@
   </footer>
 
   <script src="config/runtime-config.js"></script>
-  <script src="js/cloud/firebase-service.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.111.0/dist/umd/supabase.min.js"></script>
+  <script src="js/cloud/supabase-service.js"></script>
   <script src="js/account-page.js"></script>
 </body>
 </html>

--- a/account.html
+++ b/account.html
@@ -97,7 +97,7 @@
   </footer>
 
   <script src="config/runtime-config.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.111.0/dist/umd/supabase.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.111.0"></script>
   <script src="js/cloud/supabase-service.js"></script>
   <script src="js/account-page.js"></script>
 </body>

--- a/config/runtime-config.js
+++ b/config/runtime-config.js
@@ -1,12 +1,18 @@
-// Launch-safe defaults. Replace at deploy time; keep all integrations disabled until launch.
+// Public website runtime configuration.
+// The Supabase publishable key is safe to expose in browser code; private service keys must never be committed here.
 window.SHOWDUINO_CONFIG = Object.freeze({
-  environment: 'development',
+  environment: 'production',
   features: {
+    supabase: true,
+    authentication: true,
+    cloudSync: true,
     firebase: false,
-    authentication: false,
-    cloudSync: false,
     stripe: false,
     subscriptions: false
+  },
+  supabase: {
+    url: 'https://fczxcvlyydcqdhjkejmd.supabase.co',
+    publishableKey: 'sb_publishable_r1eWnA-Vi2HJHG3y9njZxQ_VOxivZDW'
   },
   firebase: {
     apiKey: '',

--- a/js/account-page.js
+++ b/js/account-page.js
@@ -1,44 +1,14 @@
-/* global SHOWDUINO_CONFIG, ShowduinoFirebase */
+/* global ShowduinoSupabase */
 (function () {
   'use strict';
 
   const elements = {};
 
-  function byId(id) {
-    return document.getElementById(id);
-  }
+  function byId(id) { return document.getElementById(id); }
 
   function setStatus(message, type) {
     elements.status.textContent = message;
     elements.status.className = `status-banner${type ? ` ${type}` : ''}`;
-  }
-
-  function integrationsEnabled() {
-    const config = window.SHOWDUINO_CONFIG || { features: {} };
-    return Boolean(config.features.firebase && config.features.authentication);
-  }
-
-  function renderOfflineProjects() {
-    const stored = JSON.parse(localStorage.getItem('showduino_local_projects') || '[]');
-    elements.projectList.innerHTML = '';
-
-    if (!stored.length) {
-      elements.projectList.innerHTML = '<p class="muted">No local projects yet. Create one in Showduino Studio and it will appear here once account integration is connected.</p>';
-      return;
-    }
-
-    stored.forEach((project) => {
-      const item = document.createElement('article');
-      item.className = 'project-item';
-      item.innerHTML = `
-        <div>
-          <strong>${escapeHtml(project.name || 'Untitled show')}</strong>
-          <div class="muted">Updated ${escapeHtml(project.updatedAt || 'locally')}</div>
-        </div>
-        <span class="badge">LOCAL</span>
-      `;
-      elements.projectList.appendChild(item);
-    });
   }
 
   function escapeHtml(value) {
@@ -50,26 +20,79 @@
       .replaceAll("'", '&#039;');
   }
 
+  function localProjects() {
+    try {
+      const stored = JSON.parse(localStorage.getItem('showduino_local_projects') || '[]');
+      return Array.isArray(stored) ? stored : [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  async function renderProjects(user) {
+    elements.projectList.innerHTML = '';
+    let cloud = [];
+    if (user) {
+      try { cloud = await window.ShowduinoSupabase.listProjects(); }
+      catch (error) { setStatus(`Signed in, but cloud projects could not be loaded: ${error.message}`, 'error'); }
+    }
+
+    const cloudIds = new Set(cloud.map((project) => project.id));
+    const local = localProjects().filter((project) => !cloudIds.has(project.id));
+
+    if (!cloud.length && !local.length) {
+      elements.projectList.innerHTML = '<p class="muted">No shows yet. Open Studio and create your first Showduino production.</p>';
+      return;
+    }
+
+    cloud.forEach((project) => {
+      const item = document.createElement('article');
+      item.className = 'project-item';
+      item.innerHTML = `<div><strong>${escapeHtml(project.name || 'Untitled Show')}</strong><div class="muted">Updated ${escapeHtml(new Date(project.updated_at).toLocaleString())}</div></div><span class="badge">CLOUD</span>`;
+      item.addEventListener('click', () => {
+        sessionStorage.setItem('showduino_open_cloud_project', project.id);
+        window.location.href = 'studio.html';
+      });
+      item.tabIndex = 0;
+      item.setAttribute('role', 'button');
+      item.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') item.click();
+      });
+      elements.projectList.appendChild(item);
+    });
+
+    local.forEach((project) => {
+      const item = document.createElement('article');
+      item.className = 'project-item';
+      item.innerHTML = `<div><strong>${escapeHtml(project.name || 'Untitled Show')}</strong><div class="muted">Updated ${escapeHtml(project.updatedAt || 'on this device')}</div></div><span class="badge">THIS DEVICE</span>`;
+      elements.projectList.appendChild(item);
+    });
+  }
+
   function showSignedOut() {
     elements.authForms.hidden = false;
     elements.accountPanel.hidden = true;
-    elements.signOutButton.hidden = true;
   }
 
-  function showSignedIn(user) {
+  async function showSignedIn(user) {
     elements.authForms.hidden = true;
     elements.accountPanel.hidden = false;
-    elements.signOutButton.hidden = false;
-    elements.accountName.textContent = user.displayName || 'Showduino Creator';
-    elements.accountEmail.textContent = user.email || 'No email available';
-    setStatus('You are signed in and ready to use cloud features.', 'success');
+    let displayName = user.user_metadata?.display_name || 'Showduino Creator';
+    try {
+      const profile = await window.ShowduinoSupabase.getProfile();
+      if (profile?.display_name) displayName = profile.display_name;
+    } catch (_) {}
+    elements.accountName.textContent = displayName;
+    elements.accountEmail.textContent = user.email || '';
+    setStatus('Signed in. Your cloud shows are ready.', 'success');
+    await renderProjects(user);
   }
 
   async function handleSignIn(event) {
     event.preventDefault();
     setStatus('Signing in…');
     try {
-      await window.ShowduinoFirebase.signIn(elements.loginEmail.value.trim(), elements.loginPassword.value);
+      await window.ShowduinoSupabase.signIn(elements.loginEmail.value.trim(), elements.loginPassword.value);
     } catch (error) {
       setStatus(error.message || 'Sign in failed.', 'error');
     }
@@ -77,13 +100,19 @@
 
   async function handleRegister(event) {
     event.preventDefault();
-    setStatus('Creating your account…');
+    setStatus('Creating your Showduino account…');
     try {
-      await window.ShowduinoFirebase.register(
+      const data = await window.ShowduinoSupabase.register(
         elements.registerEmail.value.trim(),
         elements.registerPassword.value,
         elements.registerName.value.trim()
       );
+      elements.registerForm.reset();
+      if (!data.session) {
+        setStatus('Account created. Check your email for the confirmation link, then return here to sign in.', 'success');
+      } else {
+        setStatus('Account created and signed in.', 'success');
+      }
     } catch (error) {
       setStatus(error.message || 'Account creation failed.', 'error');
     }
@@ -91,8 +120,9 @@
 
   async function handleSignOut() {
     try {
-      await window.ShowduinoFirebase.signOut();
+      await window.ShowduinoSupabase.signOut();
       setStatus('You have signed out.');
+      await renderProjects(null);
     } catch (error) {
       setStatus(error.message || 'Sign out failed.', 'error');
     }
@@ -102,7 +132,6 @@
     elements.status = byId('account-status');
     elements.authForms = byId('auth-forms');
     elements.accountPanel = byId('account-panel');
-    elements.signOutButton = byId('sign-out-button');
     elements.loginForm = byId('login-form');
     elements.registerForm = byId('register-form');
     elements.loginEmail = byId('login-email');
@@ -113,25 +142,27 @@
     elements.accountName = byId('account-name');
     elements.accountEmail = byId('account-email');
     elements.projectList = byId('project-list');
+    elements.signOutButton = byId('sign-out-button');
 
-    renderOfflineProjects();
     elements.loginForm.addEventListener('submit', handleSignIn);
     elements.registerForm.addEventListener('submit', handleRegister);
     elements.signOutButton.addEventListener('click', handleSignOut);
 
-    if (!integrationsEnabled() || !window.ShowduinoFirebase) {
+    if (!window.ShowduinoSupabase?.enabled()) {
       showSignedOut();
       elements.authForms.querySelectorAll('input, button').forEach((element) => { element.disabled = true; });
-      setStatus('Account registration is prepared but currently disabled while the website is being completed. Local Studio features remain available.');
+      setStatus('Showduino account services could not start. Local Studio saving is still available.', 'error');
+      renderProjects(null);
       return;
     }
 
-    setStatus('Checking your account…');
-    window.ShowduinoFirebase.onAuthChanged((user) => {
-      if (user) showSignedIn(user);
+    setStatus('Checking your Showduino account…');
+    window.ShowduinoSupabase.onAuthChanged(async (user) => {
+      if (user) await showSignedIn(user);
       else {
         showSignedOut();
-        setStatus('Sign in or create a Showduino account.');
+        setStatus('Sign in or create a free Showduino account.');
+        await renderProjects(null);
       }
     });
   }

--- a/js/cloud/supabase-service.js
+++ b/js/cloud/supabase-service.js
@@ -1,0 +1,179 @@
+/* global SHOWDUINO_CONFIG, supabase */
+(function () {
+  'use strict';
+
+  let client = null;
+
+  function config() {
+    return window.SHOWDUINO_CONFIG || { features: {}, supabase: {} };
+  }
+
+  function enabled() {
+    const cfg = config();
+    return Boolean(
+      cfg.features?.supabase &&
+      cfg.features?.authentication &&
+      cfg.supabase?.url &&
+      cfg.supabase?.publishableKey &&
+      window.supabase?.createClient
+    );
+  }
+
+  function getClient() {
+    if (!enabled()) throw new Error('Showduino cloud services are not configured.');
+    if (!client) {
+      const cfg = config().supabase;
+      client = window.supabase.createClient(cfg.url, cfg.publishableKey, {
+        auth: {
+          persistSession: true,
+          autoRefreshToken: true,
+          detectSessionInUrl: true
+        }
+      });
+    }
+    return client;
+  }
+
+  async function upsertProfile(user, displayName) {
+    if (!user) return null;
+    const name = (displayName || user.user_metadata?.display_name || 'Showduino Creator').trim().slice(0, 60);
+    const { data, error } = await getClient()
+      .from('profiles')
+      .upsert({ id: user.id, display_name: name, updated_at: new Date().toISOString() }, { onConflict: 'id' })
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
+  async function register(email, password, displayName) {
+    const redirect = `${window.location.origin}${window.location.pathname.replace(/[^/]*$/, 'account.html')}`;
+    const { data, error } = await getClient().auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: redirect,
+        data: { display_name: displayName }
+      }
+    });
+    if (error) throw error;
+    if (data.user && data.session) await upsertProfile(data.user, displayName);
+    return data;
+  }
+
+  async function signIn(email, password) {
+    const { data, error } = await getClient().auth.signInWithPassword({ email, password });
+    if (error) throw error;
+    if (data.user) await upsertProfile(data.user);
+    return data;
+  }
+
+  async function signOut() {
+    const { error } = await getClient().auth.signOut();
+    if (error) throw error;
+  }
+
+  function onAuthChanged(callback) {
+    if (!enabled()) {
+      callback(null);
+      return () => {};
+    }
+    const c = getClient();
+    c.auth.getSession().then(({ data }) => callback(data.session?.user || null));
+    const { data } = c.auth.onAuthStateChange((_event, session) => callback(session?.user || null));
+    return () => data.subscription.unsubscribe();
+  }
+
+  async function getCurrentUser() {
+    if (!enabled()) return null;
+    const { data, error } = await getClient().auth.getUser();
+    if (error) return null;
+    return data.user || null;
+  }
+
+  async function getProfile() {
+    const user = await getCurrentUser();
+    if (!user) return null;
+    const { data, error } = await getClient().from('profiles').select('id,display_name,created_at,updated_at').eq('id', user.id).maybeSingle();
+    if (error) throw error;
+    return data;
+  }
+
+  function isUuid(value) {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value || ''));
+  }
+
+  function ensureProjectUuid(project) {
+    project.project = project.project || {};
+    if (!isUuid(project.project.id)) {
+      project.project.id = window.crypto?.randomUUID?.() || '00000000-0000-4000-8000-000000000000';
+    }
+    return project.project.id;
+  }
+
+  async function saveProject(project) {
+    const user = await getCurrentUser();
+    if (!user) throw new Error('Sign in to save this show to the cloud.');
+    const id = ensureProjectUuid(project);
+    const now = new Date().toISOString();
+    project.project.updatedAt = now;
+    const payload = {
+      id,
+      user_id: user.id,
+      name: project.project.name || 'Untitled Show',
+      format: project.package?.format || 'showduino-production',
+      format_version: project.package?.version || 1,
+      project_data: project,
+      updated_at: now
+    };
+    const { data, error } = await getClient().from('projects').upsert(payload, { onConflict: 'id' }).select().single();
+    if (error) throw error;
+    return data;
+  }
+
+  async function listProjects() {
+    const user = await getCurrentUser();
+    if (!user) return [];
+    const { data, error } = await getClient()
+      .from('projects')
+      .select('id,name,format,format_version,created_at,updated_at')
+      .eq('user_id', user.id)
+      .order('updated_at', { ascending: false });
+    if (error) throw error;
+    return data || [];
+  }
+
+  async function loadProject(id) {
+    const user = await getCurrentUser();
+    if (!user) throw new Error('Sign in to load cloud shows.');
+    const { data, error } = await getClient()
+      .from('projects')
+      .select('project_data')
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .single();
+    if (error) throw error;
+    return data.project_data;
+  }
+
+  async function deleteProject(id) {
+    const user = await getCurrentUser();
+    if (!user) throw new Error('Sign in to delete cloud shows.');
+    const { error } = await getClient().from('projects').delete().eq('id', id).eq('user_id', user.id);
+    if (error) throw error;
+  }
+
+  window.ShowduinoSupabase = Object.freeze({
+    enabled,
+    register,
+    signIn,
+    signOut,
+    onAuthChanged,
+    getCurrentUser,
+    getProfile,
+    saveProject,
+    listProjects,
+    loadProject,
+    deleteProject
+  });
+})();

--- a/js/studio-creator-bootstrap.js
+++ b/js/studio-creator-bootstrap.js
@@ -1,0 +1,11 @@
+/* Showduino Studio — creator bootstrap loaded after the existing application. */
+(function () {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const project = window.state?.project;
+    if (project && window.ShowduinoPackage) {
+      window.ShowduinoPackage.ensurePackageMetadata(project);
+    }
+  });
+})();

--- a/js/studio-creator-mode.js
+++ b/js/studio-creator-mode.js
@@ -33,7 +33,12 @@
     });
 
     const connect = document.querySelector('.sidebar-nav li[data-panel="connect"]');
-    if (connect) connect.textContent = 'Send to Showduino';
+    if (connect) {
+      connect.textContent = 'Send to Showduino';
+      // Deployment/export is part of the creator workflow, not a paid live-control feature.
+      connect.classList.remove('locked');
+      connect.title = 'Prepare or send this show to your Showduino';
+    }
 
     const playback = document.querySelector('.sidebar-nav li[data-panel="playback"]');
     if (playback) playback.textContent = 'Preview Show';

--- a/js/studio-creator-mode.js
+++ b/js/studio-creator-mode.js
@@ -1,0 +1,73 @@
+/* Showduino Studio — public creator mode safety and terminology. */
+(function () {
+  'use strict';
+
+  function stopPreview() {
+    // Stop the public Studio preview only. This must never send live hardware commands.
+    if (window.timelineEditor) {
+      if (typeof window.timelineEditor.stop === 'function') {
+        window.timelineEditor.stop();
+      } else if (typeof window.timelineEditor.pause === 'function') {
+        window.timelineEditor.pause();
+      }
+    }
+
+    if (window.state) {
+      window.state.transport = 'stopped';
+      window.state.playhead = 0;
+    }
+
+    const playhead = document.querySelector('.playhead');
+    if (playhead) playhead.style.left = '0px';
+
+    if (typeof window.studioLog === 'function') {
+      window.studioLog('Preview reset. No hardware command was sent.', 'INFO');
+    }
+  }
+
+  function prepareCreatorNavigation() {
+    // The public website is for building shows. Hardware engineering pages stay on the local Showduino Studio.
+    ['live-control', 'devices', 'diagnostics'].forEach((panelName) => {
+      const item = document.querySelector(`.sidebar-nav li[data-panel="${panelName}"]`);
+      if (item) item.hidden = true;
+    });
+
+    const connect = document.querySelector('.sidebar-nav li[data-panel="connect"]');
+    if (connect) connect.textContent = 'Send to Showduino';
+
+    const playback = document.querySelector('.sidebar-nav li[data-panel="playback"]');
+    if (playback) playback.textContent = 'Preview Show';
+
+    const cloud = document.querySelector('.sidebar-nav li[data-panel="hauntsync"]');
+    if (cloud) cloud.textContent = 'My Shows / Cloud';
+  }
+
+  function prepareResetButton() {
+    const resetButton = document.querySelector('.transport-controls .panic');
+    if (!resetButton) return;
+
+    resetButton.textContent = 'RESET';
+    resetButton.title = 'Reset the browser preview only';
+    resetButton.setAttribute('aria-label', 'Reset browser preview');
+
+    // app.js contains an older hardware PANIC listener. Capture the click first and stop it here.
+    resetButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      stopPreview();
+    }, true);
+  }
+
+  function initialise() {
+    document.documentElement.dataset.studioMode = 'creator';
+    prepareCreatorNavigation();
+    prepareResetButton();
+  }
+
+  window.ShowduinoCreatorMode = Object.freeze({
+    stopPreview,
+    isCreatorMode: () => true
+  });
+
+  document.addEventListener('DOMContentLoaded', initialise);
+})();

--- a/js/studio-creator-mode.js
+++ b/js/studio-creator-mode.js
@@ -25,6 +25,13 @@
     }
   }
 
+  async function sendCurrentShow() {
+    if (!window.ShowduinoDeploy?.deployCurrentProject) {
+      throw new Error('Showduino deployment tools are still starting.');
+    }
+    return window.ShowduinoDeploy.deployCurrentProject();
+  }
+
   function prepareCreatorNavigation() {
     // The public website is for building shows. Hardware engineering pages stay on the local Showduino Studio.
     ['live-control', 'devices', 'diagnostics'].forEach((panelName) => {
@@ -35,9 +42,18 @@
     const connect = document.querySelector('.sidebar-nav li[data-panel="connect"]');
     if (connect) {
       connect.textContent = 'Send to Showduino';
-      // Deployment/export is part of the creator workflow, not a paid live-control feature.
       connect.classList.remove('locked');
       connect.title = 'Prepare or send this show to your Showduino';
+      connect.addEventListener('click', async (event) => {
+        // Stop the old navigation handler from opening engineering/network setup controls.
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        try {
+          await sendCurrentShow();
+        } catch (error) {
+          window.alert(`Could not prepare this show for Showduino.\n\n${error.message}`);
+        }
+      }, true);
     }
 
     const playback = document.querySelector('.sidebar-nav li[data-panel="playback"]');
@@ -49,17 +65,31 @@
 
   function prepareResetButton() {
     const resetButton = document.querySelector('.transport-controls .panic');
-    if (!resetButton) return;
+    if (resetButton) {
+      resetButton.textContent = 'RESET';
+      resetButton.title = 'Reset the browser preview only';
+      resetButton.setAttribute('aria-label', 'Reset browser preview');
 
-    resetButton.textContent = 'RESET';
-    resetButton.title = 'Reset the browser preview only';
-    resetButton.setAttribute('aria-label', 'Reset browser preview');
+      // app.js contains an older hardware PANIC listener. Capture the click first and stop it here.
+      resetButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        stopPreview();
+      }, true);
+    }
 
-    // app.js contains an older hardware PANIC listener. Capture the click first and stop it here.
-    resetButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      event.stopImmediatePropagation();
-      stopPreview();
+    // Preview Show is rendered later inside the workspace. Intercept its legacy PANIC/STOP
+    // control at document level so it can never fall through to old hardware-control code.
+    document.addEventListener('click', (event) => {
+      const button = event.target.closest?.('button');
+      if (!button) return;
+      const inlineAction = button.getAttribute('onclick') || '';
+      const label = (button.textContent || '').toUpperCase();
+      if (inlineAction.includes('appStop') && label.includes('PANIC')) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        stopPreview();
+      }
     }, true);
   }
 
@@ -71,6 +101,7 @@
 
   window.ShowduinoCreatorMode = Object.freeze({
     stopPreview,
+    sendCurrentShow,
     isCreatorMode: () => true
   });
 

--- a/js/studio-deploy.js
+++ b/js/studio-deploy.js
@@ -10,14 +10,6 @@
     else console.log(`[Studio Deploy] ${message}`);
   }
 
-  function currentProject() {
-    const project = window.state?.project;
-    if (!project) throw new Error('Create or load a show before deploying.');
-    return window.ShowduinoProjects?.normaliseProject
-      ? window.ShowduinoProjects.normaliseProject(project)
-      : project;
-  }
-
   function provisioningUrl(baseUrl, path) {
     const url = new URL(baseUrl);
     url.port = String(IMPORT_PORT);
@@ -57,16 +49,20 @@
     return null;
   }
 
-  async function exportForShowduino(reason) {
-    await window.ShowduinoProjects?.saveCurrentProject({ cloud: true });
+  function exportForShowduino(reason) {
     window.ShowduinoProjects.exportCurrentProject();
     notify(reason || 'Show file prepared for Showduino.', 'INFO');
     return { deployed: false, exported: true, reason: reason || 'export' };
   }
 
   async function deployCurrentProject() {
-    const project = currentProject();
-    await window.ShowduinoProjects?.saveCurrentProject({ cloud: true });
+    if (!window.ShowduinoProjects?.saveCurrentProject) {
+      throw new Error('Showduino Studio is still starting.');
+    }
+
+    // Save once locally and use exactly that saved snapshot for either deployment or export.
+    // Cloud saving is handled separately by the normal Save workflow and must not block transfer.
+    const project = await window.ShowduinoProjects.saveCurrentProject({ cloud: false });
 
     if (!browserAllowsDirectLocalSend()) {
       return exportForShowduino('Your browser protects local devices from direct website access. Downloaded the .shdo file instead.');

--- a/js/studio-deploy.js
+++ b/js/studio-deploy.js
@@ -13,7 +13,9 @@
   function currentProject() {
     const project = window.state?.project;
     if (!project) throw new Error('Create or load a show before deploying.');
-    return project;
+    return window.ShowduinoProjects?.normaliseProject
+      ? window.ShowduinoProjects.normaliseProject(project)
+      : project;
   }
 
   function provisioningUrl(baseUrl, path) {
@@ -23,6 +25,12 @@
     url.search = '';
     url.hash = '';
     return url.toString();
+  }
+
+  function browserAllowsDirectLocalSend() {
+    // showduino.com uses HTTPS. Most browsers block a secure public website from
+    // directly controlling an ordinary HTTP device on the user's private network.
+    return window.location.protocol !== 'https:';
   }
 
   async function probe(baseUrl) {
@@ -41,6 +49,7 @@
   }
 
   async function findLocalShowduino() {
+    if (!browserAllowsDirectLocalSend()) return null;
     for (const host of DEFAULT_HOSTS) {
       const found = await probe(host);
       if (found) return found;
@@ -48,16 +57,25 @@
     return null;
   }
 
+  async function exportForShowduino(reason) {
+    await window.ShowduinoProjects?.saveCurrentProject({ cloud: true });
+    window.ShowduinoProjects.exportCurrentProject();
+    notify(reason || 'Show file prepared for Showduino.', 'INFO');
+    return { deployed: false, exported: true, reason: reason || 'export' };
+  }
+
   async function deployCurrentProject() {
     const project = currentProject();
     await window.ShowduinoProjects?.saveCurrentProject({ cloud: true });
-    notify('Looking for a local Showduino…', 'NET');
 
+    if (!browserAllowsDirectLocalSend()) {
+      return exportForShowduino('Your browser protects local devices from direct website access. Downloaded the .shdo file instead.');
+    }
+
+    notify('Looking for a local Showduino…', 'NET');
     const target = await findLocalShowduino();
     if (!target) {
-      notify('No local Showduino found. Exporting .shdo instead.', 'WARN');
-      window.ShowduinoProjects.exportCurrentProject();
-      return { deployed: false, exported: true };
+      return exportForShowduino('No local Showduino was found. Downloaded the .shdo file instead.');
     }
 
     const response = await fetch(provisioningUrl(target.baseUrl, '/api/production/import'), {
@@ -78,23 +96,27 @@
   function initialise() {
     const actions = document.querySelector('.studio-project-actions');
     if (!actions || document.getElementById('studio-deploy-button')) return;
+
     const button = document.createElement('button');
     button.id = 'studio-deploy-button';
     button.className = 'studio-action-btn studio-deploy-btn';
     button.type = 'button';
     button.textContent = 'Send to Showduino';
-    button.title = 'Install this .shdo project on a Showduino connected to your local network';
+    button.title = browserAllowsDirectLocalSend()
+      ? 'Install this show on a Showduino connected to your local network'
+      : 'Prepare this show for your Showduino';
+
     button.addEventListener('click', async () => {
       button.disabled = true;
       const old = button.textContent;
-      button.textContent = 'Finding Showduino…';
+      button.textContent = browserAllowsDirectLocalSend() ? 'Finding Showduino…' : 'Preparing show…';
       try {
-        await deployCurrentProject();
-        button.textContent = 'Sent ✓';
-        setTimeout(() => { button.textContent = old; }, 1800);
+        const result = await deployCurrentProject();
+        button.textContent = result.deployed ? 'Sent ✓' : 'Show file ready ✓';
+        setTimeout(() => { button.textContent = old; }, 2200);
       } catch (error) {
         notify(`Deploy failed: ${error.message}`, 'ERR');
-        window.alert(`Could not send this show to Showduino.\n\n${error.message}\n\nYou can still use Export to save the .shdo file.`);
+        window.alert(`Could not prepare this show for Showduino.\n\n${error.message}\n\nUse Export .shdo to save the show manually.`);
         button.textContent = old;
       } finally {
         button.disabled = false;
@@ -103,6 +125,11 @@
     actions.appendChild(button);
   }
 
-  window.ShowduinoDeploy = Object.freeze({ findLocalShowduino, deployCurrentProject });
+  window.ShowduinoDeploy = Object.freeze({
+    findLocalShowduino,
+    deployCurrentProject,
+    browserAllowsDirectLocalSend
+  });
+
   document.addEventListener('DOMContentLoaded', initialise);
 })();

--- a/js/studio-package.js
+++ b/js/studio-package.js
@@ -1,0 +1,40 @@
+/* Showduino Studio — stable metadata for exported .shdo production files. */
+(function () {
+  'use strict';
+
+  const FORMAT_NAME = 'showduino-production';
+  const FORMAT_VERSION = 1;
+
+  function ensurePackageMetadata(project) {
+    if (!project || typeof project !== 'object') return project;
+
+    project.package = {
+      format: FORMAT_NAME,
+      version: FORMAT_VERSION,
+      ...(project.package && typeof project.package === 'object' ? project.package : {})
+    };
+
+    project.package.format = FORMAT_NAME;
+    project.package.version = FORMAT_VERSION;
+    return project;
+  }
+
+  function describe(project) {
+    const safe = ensurePackageMetadata(project || {});
+    return {
+      format: safe.package.format,
+      version: safe.package.version,
+      name: safe.project?.name || 'Untitled Show',
+      tracks: Array.isArray(safe.tracks) ? safe.tracks.length : 0,
+      clips: Array.isArray(safe.clips) ? safe.clips.length : 0,
+      scenes: Array.isArray(safe.scenes) ? safe.scenes.length : 0
+    };
+  }
+
+  window.ShowduinoPackage = Object.freeze({
+    FORMAT_NAME,
+    FORMAT_VERSION,
+    ensurePackageMetadata,
+    describe
+  });
+})();

--- a/js/studio-projects.js
+++ b/js/studio-projects.js
@@ -31,14 +31,42 @@
     return `show_${Date.now()}_${Math.random().toString(16).slice(2)}`;
   }
 
+  function validatePackage(project) {
+    if (!project || typeof project !== 'object') {
+      throw new Error('This is not a valid Showduino project file.');
+    }
+
+    // Older .shdo files did not have package metadata. They remain supported and are upgraded on load.
+    if (!project.package) return true;
+
+    const expectedFormat = window.ShowduinoPackage?.FORMAT_NAME || 'showduino-production';
+    const supportedVersion = window.ShowduinoPackage?.FORMAT_VERSION || 1;
+
+    if (project.package.format && project.package.format !== expectedFormat) {
+      throw new Error(`Unsupported project format: ${project.package.format}`);
+    }
+
+    const version = Number(project.package.version || 1);
+    if (!Number.isFinite(version) || version < 1) {
+      throw new Error('The .shdo file has an invalid format version.');
+    }
+    if (version > supportedVersion) {
+      throw new Error(`This show was created by a newer Showduino Studio (file version ${version}).`);
+    }
+
+    return true;
+  }
+
   function normaliseProject(project) {
+    validatePackage(project || {});
+
     const now = new Date().toISOString();
     const safeProject = project && typeof project === 'object' ? project : {};
     const metadata = safeProject.project && typeof safeProject.project === 'object'
       ? safeProject.project
       : {};
 
-    return {
+    const normalised = {
       ...safeProject,
       project: {
         id: metadata.id || createProjectId(),
@@ -55,6 +83,14 @@
       assets: safeProject.assets || {},
       metadata: safeProject.metadata || {}
     };
+
+    if (window.ShowduinoPackage) {
+      window.ShowduinoPackage.ensurePackageMetadata(normalised);
+    } else {
+      normalised.package = { format: 'showduino-production', version: 1 };
+    }
+
+    return normalised;
   }
 
   function readProjectIndex() {
@@ -78,7 +114,8 @@
       name: project.project.name,
       updatedAt: project.project.updatedAt,
       createdAt: project.project.createdAt,
-      storage: 'local'
+      storage: 'local',
+      packageVersion: project.package?.version || 1
     });
     writeProjectIndex(index.slice(0, 100));
   }
@@ -178,7 +215,7 @@
     anchor.click();
     anchor.remove();
     URL.revokeObjectURL(url);
-    notify(`Exported: ${project.project.name}`, 'INFO');
+    notify(`Exported Showduino production: ${project.project.name}`, 'INFO');
   }
 
   function importProject(file) {
@@ -192,9 +229,11 @@
       reader.onload = async () => {
         try {
           const state = getState();
-          state.project = normaliseProject(JSON.parse(String(reader.result)));
+          const parsed = JSON.parse(String(reader.result));
+          validatePackage(parsed);
+          state.project = normaliseProject(parsed);
           await saveCurrentProject({ cloud: false });
-          notify(`Imported: ${state.project.project.name}`, 'INFO');
+          notify(`Imported Showduino production: ${state.project.project.name}`, 'INFO');
           resolve(state.project);
         } catch (error) {
           reject(new Error(`Project import failed: ${error.message}`));
@@ -262,6 +301,8 @@
     importProject,
     listLocalProjects,
     renameCurrentProject,
+    normaliseProject,
+    validatePackage,
     cloudEnabled,
     getCurrentUser: () => currentUser
   });

--- a/js/studio-projects.js
+++ b/js/studio-projects.js
@@ -1,71 +1,40 @@
-/* global SHOWDUINO_CONFIG, ShowduinoFirebase */
+/* global ShowduinoSupabase */
 (function () {
   'use strict';
 
   const PROJECT_INDEX_KEY = 'showduino_local_projects';
   const PROJECT_DATA_PREFIX = 'showduino_project_';
   let currentUser = null;
+  let pendingCloudOpenHandled = false;
 
-  function getState() {
-    return window.state || null;
-  }
-
-  function getConfig() {
-    return window.SHOWDUINO_CONFIG || { features: {} };
-  }
+  function getState() { return window.state || null; }
 
   function cloudEnabled() {
-    const config = getConfig();
-    return Boolean(
-      config.features.firebase &&
-      config.features.authentication &&
-      config.features.cloudSync &&
-      window.ShowduinoFirebase
-    );
+    return Boolean(window.ShowduinoSupabase?.enabled());
   }
 
   function createProjectId() {
-    if (window.crypto && typeof window.crypto.randomUUID === 'function') {
-      return window.crypto.randomUUID();
-    }
-    return `show_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+    if (window.crypto && typeof window.crypto.randomUUID === 'function') return window.crypto.randomUUID();
+    return '00000000-0000-4000-8000-000000000000';
   }
 
   function validatePackage(project) {
-    if (!project || typeof project !== 'object') {
-      throw new Error('This is not a valid Showduino project file.');
-    }
-
-    // Older .shdo files did not have package metadata. They remain supported and are upgraded on load.
+    if (!project || typeof project !== 'object') throw new Error('This is not a valid Showduino project file.');
     if (!project.package) return true;
-
     const expectedFormat = window.ShowduinoPackage?.FORMAT_NAME || 'showduino-production';
     const supportedVersion = window.ShowduinoPackage?.FORMAT_VERSION || 1;
-
-    if (project.package.format && project.package.format !== expectedFormat) {
-      throw new Error(`Unsupported project format: ${project.package.format}`);
-    }
-
+    if (project.package.format && project.package.format !== expectedFormat) throw new Error(`Unsupported project format: ${project.package.format}`);
     const version = Number(project.package.version || 1);
-    if (!Number.isFinite(version) || version < 1) {
-      throw new Error('The .shdo file has an invalid format version.');
-    }
-    if (version > supportedVersion) {
-      throw new Error(`This show was created by a newer Showduino Studio (file version ${version}).`);
-    }
-
+    if (!Number.isFinite(version) || version < 1) throw new Error('The .shdo file has an invalid format version.');
+    if (version > supportedVersion) throw new Error(`This show was created by a newer Showduino Studio (file version ${version}).`);
     return true;
   }
 
   function normaliseProject(project) {
     validatePackage(project || {});
-
     const now = new Date().toISOString();
     const safeProject = project && typeof project === 'object' ? project : {};
-    const metadata = safeProject.project && typeof safeProject.project === 'object'
-      ? safeProject.project
-      : {};
-
+    const metadata = safeProject.project && typeof safeProject.project === 'object' ? safeProject.project : {};
     const normalised = {
       ...safeProject,
       project: {
@@ -83,13 +52,8 @@
       assets: safeProject.assets || {},
       metadata: safeProject.metadata || {}
     };
-
-    if (window.ShowduinoPackage) {
-      window.ShowduinoPackage.ensurePackageMetadata(normalised);
-    } else {
-      normalised.package = { format: 'showduino-production', version: 1 };
-    }
-
+    if (window.ShowduinoPackage) window.ShowduinoPackage.ensurePackageMetadata(normalised);
+    else normalised.package = { format: 'showduino-production', version: 1 };
     return normalised;
   }
 
@@ -103,9 +67,7 @@
     }
   }
 
-  function writeProjectIndex(index) {
-    localStorage.setItem(PROJECT_INDEX_KEY, JSON.stringify(index));
-  }
+  function writeProjectIndex(index) { localStorage.setItem(PROJECT_INDEX_KEY, JSON.stringify(index)); }
 
   function updateProjectIndex(project) {
     const index = readProjectIndex().filter((item) => item.id !== project.project.id);
@@ -114,7 +76,7 @@
       name: project.project.name,
       updatedAt: project.project.updatedAt,
       createdAt: project.project.createdAt,
-      storage: 'local',
+      storage: currentUser ? 'local+cloud' : 'local',
       packageVersion: project.package?.version || 1
     });
     writeProjectIndex(index.slice(0, 100));
@@ -127,11 +89,8 @@
   }
 
   function notify(message, level) {
-    if (typeof window.studioLog === 'function') {
-      window.studioLog(message, level || 'INFO');
-    } else {
-      console.log(`[Studio Projects] ${message}`);
-    }
+    if (typeof window.studioLog === 'function') window.studioLog(message, level || 'INFO');
+    else console.log(`[Studio Projects] ${message}`);
   }
 
   function ensureProject() {
@@ -146,20 +105,20 @@
     const settings = { cloud: true, ...options };
     const project = ensureProject();
     project.project.updatedAt = new Date().toISOString();
-
     localStorage.setItem(`${PROJECT_DATA_PREFIX}${project.project.id}`, JSON.stringify(project));
     updateProjectIndex(project);
     updateStudioTitle(project);
-    notify(`Saved locally: ${project.project.name}`, 'INFO');
+    notify(`Saved on this device: ${project.project.name}`, 'INFO');
 
+    let cloudSaved = false;
     if (settings.cloud && cloudEnabled() && currentUser) {
-      await window.ShowduinoFirebase.saveProject(project);
-      notify(`Synced to HauntSync: ${project.project.name}`, 'NET');
+      await window.ShowduinoSupabase.saveProject(project);
+      cloudSaved = true;
+      updateProjectIndex(project);
+      notify(`Saved to your Showduino cloud: ${project.project.name}`, 'NET');
     }
 
-    window.dispatchEvent(new CustomEvent('showduino:project-saved', {
-      detail: { project, cloud: Boolean(settings.cloud && cloudEnabled() && currentUser) }
-    }));
+    window.dispatchEvent(new CustomEvent('showduino:project-saved', { detail: { project, cloud: cloudSaved } }));
     return project;
   }
 
@@ -168,30 +127,35 @@
     if (!state) throw new Error('Studio is still starting.');
     const raw = localStorage.getItem(`${PROJECT_DATA_PREFIX}${projectId}`);
     if (!raw) throw new Error('The local project could not be found.');
-
     const project = normaliseProject(JSON.parse(raw));
     state.project = project;
     updateProjectIndex(project);
     updateStudioTitle(project);
-    notify(`Loaded local project: ${project.project.name}`, 'INFO');
-
-    if (window.timelineEditor && typeof window.timelineEditor.init === 'function') {
-      window.timelineEditor.init();
-    }
+    notify(`Loaded from this device: ${project.project.name}`, 'INFO');
+    if (window.timelineEditor && typeof window.timelineEditor.init === 'function') window.timelineEditor.init();
     return project;
   }
 
   async function loadCloudProject(projectId) {
-    if (!cloudEnabled() || !currentUser) {
-      throw new Error('Sign in and enable cloud sync before loading cloud projects.');
-    }
+    if (!cloudEnabled() || !currentUser) throw new Error('Sign in before loading a cloud show.');
     const state = getState();
-    const project = await window.ShowduinoFirebase.loadProject(projectId);
+    const project = await window.ShowduinoSupabase.loadProject(projectId);
     if (!project) throw new Error('The cloud project could not be found.');
     state.project = normaliseProject(project);
     await saveCurrentProject({ cloud: false });
-    notify(`Loaded from HauntSync: ${state.project.project.name}`, 'NET');
+    notify(`Loaded from your Showduino cloud: ${state.project.project.name}`, 'NET');
+    if (window.timelineEditor && typeof window.timelineEditor.init === 'function') window.timelineEditor.init();
     return state.project;
+  }
+
+  async function openRequestedCloudProject() {
+    if (pendingCloudOpenHandled || !currentUser) return;
+    const id = sessionStorage.getItem('showduino_open_cloud_project');
+    if (!id) return;
+    pendingCloudOpenHandled = true;
+    sessionStorage.removeItem('showduino_open_cloud_project');
+    try { await loadCloudProject(id); }
+    catch (error) { notify(`Could not open cloud show: ${error.message}`, 'ERR'); }
   }
 
   function renameCurrentProject() {
@@ -201,7 +165,7 @@
     project.project.name = requestedName.trim().slice(0, 100);
     project.project.updatedAt = new Date().toISOString();
     updateStudioTitle(project);
-    saveCurrentProject({ cloud: false }).catch((error) => notify(error.message, 'ERR'));
+    saveCurrentProject().catch((error) => notify(error.message, 'ERR'));
   }
 
   function exportCurrentProject() {
@@ -220,11 +184,7 @@
 
   function importProject(file) {
     return new Promise((resolve, reject) => {
-      if (!file) {
-        reject(new Error('Choose a .shdo or JSON project file.'));
-        return;
-      }
-
+      if (!file) return reject(new Error('Choose a .shdo or JSON project file.'));
       const reader = new FileReader();
       reader.onload = async () => {
         try {
@@ -232,7 +192,7 @@
           const parsed = JSON.parse(String(reader.result));
           validatePackage(parsed);
           state.project = normaliseProject(parsed);
-          await saveCurrentProject({ cloud: false });
+          await saveCurrentProject();
           notify(`Imported Showduino production: ${state.project.project.name}`, 'INFO');
           resolve(state.project);
         } catch (error) {
@@ -244,20 +204,18 @@
     });
   }
 
-  function listLocalProjects() {
-    return readProjectIndex();
-  }
+  function listLocalProjects() { return readProjectIndex(); }
 
   function initialiseAuth() {
     if (!cloudEnabled()) {
       currentUser = null;
       return;
     }
-
-    window.ShowduinoFirebase.onAuthChanged((user) => {
+    window.ShowduinoSupabase.onAuthChanged(async (user) => {
       currentUser = user;
       window.dispatchEvent(new CustomEvent('showduino:auth-changed', { detail: { user } }));
-      notify(user ? `HauntSync account connected: ${user.email || user.displayName}` : 'HauntSync account disconnected', 'NET');
+      notify(user ? `Showduino account connected: ${user.email || 'signed in'}` : 'Using local project saving only', user ? 'NET' : 'INFO');
+      if (user) await openRequestedCloudProject();
     });
   }
 
@@ -265,11 +223,9 @@
     const saveButton = document.querySelector('.save-icon');
     if (saveButton) {
       saveButton.type = 'button';
-      saveButton.title = 'Save project locally';
-      saveButton.setAttribute('aria-label', 'Save project locally');
-      saveButton.addEventListener('click', () => {
-        saveCurrentProject().catch((error) => notify(error.message, 'ERR'));
-      });
+      saveButton.title = 'Save this show';
+      saveButton.setAttribute('aria-label', 'Save this show');
+      saveButton.addEventListener('click', () => saveCurrentProject().catch((error) => notify(error.message, 'ERR')));
     }
 
     const name = document.querySelector('.show-name');

--- a/studio.html
+++ b/studio.html
@@ -27,14 +27,11 @@
             <nav class="sidebar-nav" aria-label="Studio navigation">
                 <ul>
                     <li class="active" data-panel="introduction" tabindex="0">Introduction</li>
-                    <li data-panel="connect" tabindex="0">Deploy / Connect</li>
-                    <li data-panel="live-control" tabindex="0">Preview Control</li>
                     <li data-panel="timeline-editor" tabindex="0">Timeline Editor</li>
-                    <li data-panel="playback" tabindex="0">Preview Playback</li>
+                    <li data-panel="playback" tabindex="0">Preview Show</li>
                     <li data-panel="audio-manager" tabindex="0">Audio Manager</li>
-                    <li data-panel="devices" tabindex="0">Device Targets</li>
-                    <li data-panel="diagnostics" tabindex="0">Compatibility</li>
-                    <li data-panel="hauntsync" tabindex="0">HauntSync (Cloud)</li>
+                    <li data-panel="hauntsync" tabindex="0">My Shows / Cloud</li>
+                    <li data-panel="connect" tabindex="0">Send to Showduino</li>
                     <li data-panel="settings" tabindex="0">Settings</li>
                     <li data-panel="help" tabindex="0">Help</li>
                 </ul>
@@ -45,7 +42,7 @@
                 <div style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;">
                     <a href="index.html" class="back-to-menu-btn">← Website</a>
                     <a href="account.html" class="back-to-menu-btn">Account</a>
-                    <div class="connection-status offline" role="status">OFFLINE</div>
+                    <div class="connection-status offline" role="status">CREATOR OFFLINE</div>
                 </div>
                 <div class="show-info">
                     <span class="show-name" role="button" aria-label="Rename show">Untitled Show</span>
@@ -60,7 +57,7 @@
                     <button type="button" aria-label="Preview play" title="Preview in Studio">▶</button>
                     <button type="button" aria-label="Preview stop" title="Stop preview">■</button>
                     <button type="button" aria-label="Record automation" title="Record automation">●</button>
-                    <button type="button" class="panic" title="Reset preview outputs">RESET</button>
+                    <button type="button" class="panic" title="Reset browser preview only">RESET</button>
                 </div>
                 <div class="system-info"><span class="clock">12:00:00</span><span class="latency">Creator</span></div>
             </header>
@@ -95,8 +92,11 @@
     <script src="js/led_studio.js"></script>
     <script src="js/panels.js"></script>
     <script src="app.js"></script>
+    <script src="js/studio-package.js"></script>
+    <script src="js/studio-creator-mode.js"></script>
     <script src="js/studio-projects.js"></script>
     <script src="js/studio-deploy.js"></script>
+    <script src="js/studio-creator-bootstrap.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', async () => {
             window.connectionDetector = new window.ConnectionDetector();
@@ -105,7 +105,7 @@
             const updateConnectionUI = () => {
                 const status = document.querySelector('.connection-status');
                 if (!status) return;
-                if (window.connectionDetector.isAPMode()) { status.className='connection-status ap'; status.textContent='SHOWDUINO AP'; }
+                if (window.connectionDetector.isAPMode()) { status.className='connection-status ap'; status.textContent='SHOWDUINO FOUND'; }
                 else if (window.connectionDetector.isOffline()) { status.className='connection-status offline'; status.textContent='CREATOR OFFLINE'; }
                 else { status.className='connection-status lan'; status.textContent=window.ShowduinoProjects?.cloudEnabled()?'CREATOR + CLOUD':'CREATOR ONLINE'; }
             };

--- a/studio.html
+++ b/studio.html
@@ -79,7 +79,8 @@
         </footer>
     </div>
     <script src="config/runtime-config.js"></script>
-    <script src="js/cloud/firebase-service.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.111.0/dist/umd/supabase.min.js"></script>
+    <script src="js/cloud/supabase-service.js"></script>
     <script src="js/api.js"></script>
     <script src="js/shdo_model.js"></script>
     <script src="js/connection_detector.js"></script>
@@ -102,15 +103,18 @@
             window.connectionDetector = new window.ConnectionDetector();
             await window.connectionDetector.detectMode();
             window.connectionDetector.startMonitoring();
-            const updateConnectionUI = () => {
-                const status = document.querySelector('.connection-status');
+            const status = document.querySelector('.connection-status');
+            const refreshCloudStatus = async () => {
                 if (!status) return;
+                const user = await window.ShowduinoSupabase?.getCurrentUser?.();
                 if (window.connectionDetector.isAPMode()) { status.className='connection-status ap'; status.textContent='SHOWDUINO FOUND'; }
-                else if (window.connectionDetector.isOffline()) { status.className='connection-status offline'; status.textContent='CREATOR OFFLINE'; }
-                else { status.className='connection-status lan'; status.textContent=window.ShowduinoProjects?.cloudEnabled()?'CREATOR + CLOUD':'CREATOR ONLINE'; }
+                else if (user) { status.className='connection-status lan'; status.textContent='SIGNED IN + CLOUD'; }
+                else if (navigator.onLine) { status.className='connection-status lan'; status.textContent='CREATOR ONLINE'; }
+                else { status.className='connection-status offline'; status.textContent='CREATOR OFFLINE'; }
             };
-            updateConnectionUI();
-            window.setInterval(updateConnectionUI,5000);
+            refreshCloudStatus();
+            window.addEventListener('showduino:auth-changed', refreshCloudStatus);
+            window.setInterval(refreshCloudStatus,5000);
             const importButton=document.getElementById('studio-import-button');
             const exportButton=document.getElementById('studio-export-button');
             const importFile=document.getElementById('studio-import-file');


### PR DESCRIPTION
## What this changes

This update turns the public Showduino Studio into a creator-focused product and connects the website to a real Supabase backend for user accounts and cloud show storage.

### Showduino accounts + Supabase
- Adds real email/password signup and login.
- Adds persistent signed-in sessions.
- Adds a private `profiles` area for each account.
- Adds a private `projects` area for saved Showduino productions.
- Adds database security rules so users can only read/change/delete their own profile and projects.
- Adds cloud project listing on the Account page.
- Clicking a cloud project opens that show back in Studio.
- Studio Save keeps a local copy and saves to Supabase when signed in.
- Uses only the public Supabase browser key; no admin/service key is exposed.

### Creator-focused Studio
- Simplifies public Studio navigation to Timeline Editor, Preview Show, Audio Manager, My Shows / Cloud, Send to Showduino, Settings and Help.
- Keeps hardware engineering pages out of the public creator navigation.
- Routes `Send to Showduino` into the actual deployment/export flow instead of the old connection-settings panel.
- Changes PANIC-style controls into browser-preview reset controls so the public website cannot accidentally issue the old live hardware stop behaviour.

### .shdo production files
- Adds package metadata identifying exports as `showduino-production`, format version `1`.
- Older `.shdo` files without metadata still import and are upgraded on load.
- Malformed/newer unsupported package versions are rejected clearly.

### Send to Showduino
- Saves one local project snapshot before transfer.
- Reuses that exact snapshot for deployment/export.
- Direct local sending is attempted only where the browser allows it.
- On normal HTTPS showduino.com sessions, Studio falls back to downloading the `.shdo` production file rather than failing with a confusing browser-security error.

### Verification
- Supabase project is active and healthy in London (`eu-west-2`).
- Supabase security advisor reports no security findings.
- Row-level security policies were verified for profiles and projects.
- Cloudflare branch deployment succeeded.
- CodeRabbit status is passing and all actionable review threads have been addressed/resolved.

### Known external step
Supabase email confirmation is handled by Supabase itself. The code path is implemented and the website tells new users to confirm their email and return to sign in, but this PR cannot simulate a real user's inbox click.

### Hardware
No C3/P4 hardware change is included here. The current C3 remains unchanged; an ESP32-S3 upgrade remains a future hardware option only.