### PR TITLE
Fix Supabase confirmation redirect and account recovery

### DIFF
--- a/account.html
+++ b/account.html
@@ -40,7 +40,10 @@
           <label for="login-password">Password</label>
           <input id="login-password" class="form-control" type="password" autocomplete="current-password" minlength="8" required>
         </div>
-        <button class="btn" type="submit">Sign in</button>
+        <div class="button-row">
+          <button class="btn" type="submit">Sign in</button>
+          <button id="forgot-password-button" class="btn secondary" type="button">Forgot password?</button>
+        </div>
       </form>
 
       <form id="register-form" class="card">
@@ -59,6 +62,23 @@
           <input id="register-password" class="form-control" type="password" autocomplete="new-password" minlength="8" required>
         </div>
         <button class="btn" type="submit">Create account</button>
+      </form>
+    </section>
+
+    <section id="password-recovery-panel" class="card" hidden>
+      <span class="badge">PASSWORD RECOVERY</span>
+      <h2>Choose a new password</h2>
+      <p class="muted">Enter a new password for your Showduino account.</p>
+      <form id="password-recovery-form">
+        <div class="form-group">
+          <label for="recovery-password">New password</label>
+          <input id="recovery-password" class="form-control" type="password" autocomplete="new-password" minlength="8" required>
+        </div>
+        <div class="form-group">
+          <label for="recovery-password-confirm">Confirm new password</label>
+          <input id="recovery-password-confirm" class="form-control" type="password" autocomplete="new-password" minlength="8" required>
+        </div>
+        <button class="btn" type="submit">Save new password</button>
       </form>
     </section>
 

--- a/js/account-page.js
+++ b/js/account-page.js
@@ -3,6 +3,7 @@
   'use strict';
 
   const elements = {};
+  let recoveryMode = false;
 
   function byId(id) { return document.getElementById(id); }
 
@@ -70,13 +71,17 @@
   }
 
   function showSignedOut() {
+    if (recoveryMode) return;
     elements.authForms.hidden = false;
     elements.accountPanel.hidden = true;
+    elements.recoveryPanel.hidden = true;
   }
 
   async function showSignedIn(user) {
+    if (recoveryMode) return;
     elements.authForms.hidden = true;
     elements.accountPanel.hidden = false;
+    elements.recoveryPanel.hidden = true;
     let displayName = user.user_metadata?.display_name || 'Showduino Creator';
     try {
       const profile = await window.ShowduinoSupabase.getProfile();
@@ -88,13 +93,26 @@
     await renderProjects(user);
   }
 
+  function showRecoveryMode() {
+    recoveryMode = true;
+    elements.authForms.hidden = true;
+    elements.accountPanel.hidden = true;
+    elements.recoveryPanel.hidden = false;
+    setStatus('Password reset link accepted. Choose a new password below.', 'success');
+  }
+
   async function handleSignIn(event) {
     event.preventDefault();
     setStatus('Signing in…');
     try {
       await window.ShowduinoSupabase.signIn(elements.loginEmail.value.trim(), elements.loginPassword.value);
     } catch (error) {
-      setStatus(error.message || 'Sign in failed.', 'error');
+      const message = String(error.message || 'Sign in failed.');
+      if (message.toLowerCase().includes('invalid login credentials')) {
+        setStatus('That email/password combination was not recognised. If you are unsure of the password, use “Forgot password?” below.', 'error');
+      } else {
+        setStatus(message, 'error');
+      }
     }
   }
 
@@ -109,12 +127,53 @@
       );
       elements.registerForm.reset();
       if (!data.session) {
-        setStatus('Account created. Check your email for the confirmation link, then return here to sign in.', 'success');
+        setStatus('Account created. Check your email and tap Confirm. You will be returned to showduino.com to finish signing in.', 'success');
       } else {
         setStatus('Account created and signed in.', 'success');
       }
     } catch (error) {
       setStatus(error.message || 'Account creation failed.', 'error');
+    }
+  }
+
+  async function handleForgotPassword() {
+    const email = elements.loginEmail.value.trim();
+    if (!email) {
+      setStatus('Enter your email address in the Sign in box first, then tap “Forgot password?”.', 'error');
+      elements.loginEmail.focus();
+      return;
+    }
+    setStatus('Sending password reset email…');
+    try {
+      await window.ShowduinoSupabase.requestPasswordReset(email);
+      setStatus('Password reset email sent. Open it and follow the link back to Showduino.', 'success');
+    } catch (error) {
+      setStatus(error.message || 'Password reset email could not be sent.', 'error');
+    }
+  }
+
+  async function handleRecoverySubmit(event) {
+    event.preventDefault();
+    const password = elements.recoveryPassword.value;
+    const confirm = elements.recoveryPasswordConfirm.value;
+    if (password !== confirm) {
+      setStatus('The two passwords do not match.', 'error');
+      return;
+    }
+    setStatus('Saving your new password…');
+    try {
+      await window.ShowduinoSupabase.updatePassword(password);
+      recoveryMode = false;
+      elements.recoveryForm.reset();
+      history.replaceState(null, '', 'account.html');
+      const user = await window.ShowduinoSupabase.getCurrentUser();
+      if (user) await showSignedIn(user);
+      else {
+        showSignedOut();
+        setStatus('Password updated. Sign in with your new password.', 'success');
+      }
+    } catch (error) {
+      setStatus(error.message || 'Your password could not be updated.', 'error');
     }
   }
 
@@ -132,21 +191,28 @@
     elements.status = byId('account-status');
     elements.authForms = byId('auth-forms');
     elements.accountPanel = byId('account-panel');
+    elements.recoveryPanel = byId('password-recovery-panel');
     elements.loginForm = byId('login-form');
     elements.registerForm = byId('register-form');
+    elements.recoveryForm = byId('password-recovery-form');
     elements.loginEmail = byId('login-email');
     elements.loginPassword = byId('login-password');
     elements.registerName = byId('register-name');
     elements.registerEmail = byId('register-email');
     elements.registerPassword = byId('register-password');
+    elements.recoveryPassword = byId('recovery-password');
+    elements.recoveryPasswordConfirm = byId('recovery-password-confirm');
     elements.accountName = byId('account-name');
     elements.accountEmail = byId('account-email');
     elements.projectList = byId('project-list');
     elements.signOutButton = byId('sign-out-button');
+    elements.forgotPasswordButton = byId('forgot-password-button');
 
     elements.loginForm.addEventListener('submit', handleSignIn);
     elements.registerForm.addEventListener('submit', handleRegister);
+    elements.recoveryForm.addEventListener('submit', handleRecoverySubmit);
     elements.signOutButton.addEventListener('click', handleSignOut);
+    elements.forgotPasswordButton.addEventListener('click', handleForgotPassword);
 
     if (!window.ShowduinoSupabase?.enabled()) {
       showSignedOut();
@@ -157,7 +223,12 @@
     }
 
     setStatus('Checking your Showduino account…');
-    window.ShowduinoSupabase.onAuthChanged(async (user) => {
+    window.ShowduinoSupabase.onAuthChanged(async (user, event) => {
+      if (event === 'PASSWORD_RECOVERY') {
+        showRecoveryMode();
+        return;
+      }
+      if (recoveryMode) return;
       if (user) await showSignedIn(user);
       else {
         showSignedOut();

--- a/js/cloud/supabase-service.js
+++ b/js/cloud/supabase-service.js
@@ -2,6 +2,7 @@
 (function () {
   'use strict';
 
+  const ACCOUNT_URL = 'https://showduino.com/account.html';
   let client = null;
 
   function config() {
@@ -47,12 +48,11 @@
   }
 
   async function register(email, password, displayName) {
-    const redirect = `${window.location.origin}${window.location.pathname.replace(/[^/]*$/, 'account.html')}`;
     const { data, error } = await getClient().auth.signUp({
       email,
       password,
       options: {
-        emailRedirectTo: redirect,
+        emailRedirectTo: ACCOUNT_URL,
         data: { display_name: displayName }
       }
     });
@@ -68,6 +68,20 @@
     return data;
   }
 
+  async function requestPasswordReset(email) {
+    const { data, error } = await getClient().auth.resetPasswordForEmail(email, {
+      redirectTo: ACCOUNT_URL
+    });
+    if (error) throw error;
+    return data;
+  }
+
+  async function updatePassword(password) {
+    const { data, error } = await getClient().auth.updateUser({ password });
+    if (error) throw error;
+    return data;
+  }
+
   async function signOut() {
     const { error } = await getClient().auth.signOut();
     if (error) throw error;
@@ -75,12 +89,12 @@
 
   function onAuthChanged(callback) {
     if (!enabled()) {
-      callback(null);
+      callback(null, 'DISABLED');
       return () => {};
     }
     const c = getClient();
-    c.auth.getSession().then(({ data }) => callback(data.session?.user || null));
-    const { data } = c.auth.onAuthStateChange((_event, session) => callback(session?.user || null));
+    c.auth.getSession().then(({ data }) => callback(data.session?.user || null, 'INITIAL_SESSION'));
+    const { data } = c.auth.onAuthStateChange((event, session) => callback(session?.user || null, event));
     return () => data.subscription.unsubscribe();
   }
 
@@ -167,6 +181,8 @@
     enabled,
     register,
     signIn,
+    requestPasswordReset,
+    updatePassword,
     signOut,
     onAuthChanged,
     getCurrentUser,


### PR DESCRIPTION
## What this fixes

This corrects the account issue seen after signup where Supabase confirmation links returned users to `localhost:3000` instead of the real Showduino website.

### Email confirmation
- Signup confirmation emails now always return to `https://showduino.com/account.html`.
- The redirect no longer depends on whatever preview/local page the signup happened from.
- Supabase's own auth logs confirmed the user's first email confirmation succeeded; the later expired-link message was from reusing the same one-time confirmation link.

### Sign-in clarity
- Replaces the raw `Invalid login credentials` message with a beginner-friendly explanation and points users to password recovery.

### Password recovery
- Adds a `Forgot password?` action to the account page.
- Password reset emails return to the real Showduino account page.
- The account page detects the password-recovery session and shows a dedicated `Choose a new password` form.
- After saving the new password, the account returns to the normal signed-in state.

### Scope
- No changes to project storage, Studio timelines, `.shdo`, or Supabase database tables.
