### PR TITLE
Fix Showduino email confirmation and auth recovery flow

### DIFF
--- a/account.html
+++ b/account.html
@@ -58,7 +58,11 @@
           <label for="register-password">Password</label>
           <input id="register-password" class="form-control" type="password" autocomplete="new-password" minlength="8" required>
         </div>
-        <button class="btn" type="submit">Create account</button>
+        <div class="button-row">
+          <button class="btn" type="submit">Create account</button>
+          <button id="resend-confirmation-button" class="btn secondary" type="button">Resend confirmation</button>
+        </div>
+        <p class="muted" style="margin-top:.75rem;">If your confirmation link expires or goes missing, enter your email above and tap “Resend confirmation”.</p>
       </form>
     </section>
 
@@ -93,7 +97,7 @@
   </main>
 
   <footer class="site-footer">
-    <p>© 2026 Showduino · Built for immersive creators.</p>
+    <p>© 2026 Showduino · Show control so good, it’s frightening.</p>
   </footer>
 
   <script src="config/runtime-config.js"></script>

--- a/js/account-page.js
+++ b/js/account-page.js
@@ -3,12 +3,28 @@
   'use strict';
 
   const elements = {};
+  const params = new URLSearchParams(window.location.search);
+  const confirmationReturn = params.get('confirmed') === '1';
 
   function byId(id) { return document.getElementById(id); }
 
   function setStatus(message, type) {
     elements.status.textContent = message;
     elements.status.className = `status-banner${type ? ` ${type}` : ''}`;
+  }
+
+  function friendlyAuthMessage(error, fallback) {
+    const message = String(error?.message || fallback || 'Something went wrong.');
+    if (/invalid login credentials/i.test(message)) {
+      return 'That email address and password did not match. If you just created the account, make sure the confirmation email has been opened first.';
+    }
+    if (/email not confirmed/i.test(message)) {
+      return 'Your Showduino ID is waiting for email confirmation. Open the confirmation email, or use “Resend confirmation”.';
+    }
+    if (/expired|invalid.*link|token/i.test(message)) {
+      return 'That confirmation link has expired or has already been used. Enter your email and choose “Resend confirmation”.';
+    }
+    return message;
   }
 
   function escapeHtml(value) {
@@ -84,7 +100,12 @@
     } catch (_) {}
     elements.accountName.textContent = displayName;
     elements.accountEmail.textContent = user.email || '';
-    setStatus('Signed in. Your cloud shows are ready.', 'success');
+    setStatus(
+      confirmationReturn
+        ? 'Email confirmed — welcome to Showduino. Your Showduino ID is ready.'
+        : 'Signed in. Your cloud shows are ready.',
+      'success'
+    );
     await renderProjects(user);
   }
 
@@ -94,7 +115,7 @@
     try {
       await window.ShowduinoSupabase.signIn(elements.loginEmail.value.trim(), elements.loginPassword.value);
     } catch (error) {
-      setStatus(error.message || 'Sign in failed.', 'error');
+      setStatus(friendlyAuthMessage(error, 'Sign in failed.'), 'error');
     }
   }
 
@@ -102,19 +123,42 @@
     event.preventDefault();
     setStatus('Creating your Showduino account…');
     try {
+      const email = elements.registerEmail.value.trim();
       const data = await window.ShowduinoSupabase.register(
-        elements.registerEmail.value.trim(),
+        email,
         elements.registerPassword.value,
         elements.registerName.value.trim()
       );
-      elements.registerForm.reset();
+      sessionStorage.setItem('showduino_pending_confirmation_email', email);
+      elements.registerPassword.value = '';
       if (!data.session) {
-        setStatus('Account created. Check your email for the confirmation link, then return here to sign in.', 'success');
+        setStatus('Showduino ID created. Check your email and tap “Confirm Email Address”. You will return here automatically.', 'success');
       } else {
         setStatus('Account created and signed in.', 'success');
       }
     } catch (error) {
-      setStatus(error.message || 'Account creation failed.', 'error');
+      setStatus(friendlyAuthMessage(error, 'Account creation failed.'), 'error');
+    }
+  }
+
+  async function handleResendConfirmation() {
+    const email = (
+      elements.registerEmail.value.trim() ||
+      elements.loginEmail.value.trim() ||
+      sessionStorage.getItem('showduino_pending_confirmation_email') ||
+      ''
+    );
+    if (!email) {
+      setStatus('Enter the email address you used to create your Showduino ID, then tap “Resend confirmation”.', 'error');
+      return;
+    }
+    setStatus('Sending a fresh Showduino confirmation email…');
+    try {
+      await window.ShowduinoSupabase.resendConfirmation(email);
+      sessionStorage.setItem('showduino_pending_confirmation_email', email);
+      setStatus('Fresh confirmation email sent. Open it and tap “Confirm Email Address”.', 'success');
+    } catch (error) {
+      setStatus(friendlyAuthMessage(error, 'The confirmation email could not be resent.'), 'error');
     }
   }
 
@@ -124,8 +168,16 @@
       setStatus('You have signed out.');
       await renderProjects(null);
     } catch (error) {
-      setStatus(error.message || 'Sign out failed.', 'error');
+      setStatus(friendlyAuthMessage(error, 'Sign out failed.'), 'error');
     }
+  }
+
+  function handleConfirmationErrorInUrl() {
+    const hash = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    const description = hash.get('error_description') || params.get('error_description');
+    if (!description) return false;
+    setStatus(friendlyAuthMessage({ message: description }, description), 'error');
+    return true;
   }
 
   function initialise() {
@@ -143,9 +195,17 @@
     elements.accountEmail = byId('account-email');
     elements.projectList = byId('project-list');
     elements.signOutButton = byId('sign-out-button');
+    elements.resendConfirmationButton = byId('resend-confirmation-button');
+
+    const pendingEmail = sessionStorage.getItem('showduino_pending_confirmation_email');
+    if (pendingEmail) {
+      elements.registerEmail.value = pendingEmail;
+      elements.loginEmail.value = pendingEmail;
+    }
 
     elements.loginForm.addEventListener('submit', handleSignIn);
     elements.registerForm.addEventListener('submit', handleRegister);
+    elements.resendConfirmationButton.addEventListener('click', handleResendConfirmation);
     elements.signOutButton.addEventListener('click', handleSignOut);
 
     if (!window.ShowduinoSupabase?.enabled()) {
@@ -156,12 +216,25 @@
       return;
     }
 
-    setStatus('Checking your Showduino account…');
+    const hadUrlError = handleConfirmationErrorInUrl();
+    if (!hadUrlError) {
+      setStatus(confirmationReturn ? 'Finishing your Showduino email confirmation…' : 'Checking your Showduino account…');
+    }
+
     window.ShowduinoSupabase.onAuthChanged(async (user) => {
-      if (user) await showSignedIn(user);
-      else {
+      if (user) {
+        sessionStorage.removeItem('showduino_pending_confirmation_email');
+        await showSignedIn(user);
+      } else {
         showSignedOut();
-        setStatus('Sign in or create a free Showduino account.');
+        if (!hadUrlError) {
+          setStatus(
+            confirmationReturn
+              ? 'Email confirmed. Sign in to finish opening your Showduino ID.'
+              : 'Sign in or create a free Showduino account.',
+            confirmationReturn ? 'success' : undefined
+          );
+        }
         await renderProjects(null);
       }
     });

--- a/js/cloud/supabase-service.js
+++ b/js/cloud/supabase-service.js
@@ -2,6 +2,7 @@
 (function () {
   'use strict';
 
+  const CONFIRMATION_REDIRECT = 'https://show-duino.com/account.html?confirmed=1';
   let client = null;
 
   function config() {
@@ -47,17 +48,28 @@
   }
 
   async function register(email, password, displayName) {
-    const redirect = `${window.location.origin}${window.location.pathname.replace(/[^/]*$/, 'account.html')}`;
     const { data, error } = await getClient().auth.signUp({
       email,
       password,
       options: {
-        emailRedirectTo: redirect,
+        emailRedirectTo: CONFIRMATION_REDIRECT,
         data: { display_name: displayName }
       }
     });
     if (error) throw error;
     if (data.user && data.session) await upsertProfile(data.user, displayName);
+    return data;
+  }
+
+  async function resendConfirmation(email) {
+    const address = String(email || '').trim();
+    if (!address) throw new Error('Enter the email address you used to sign up first.');
+    const { data, error } = await getClient().auth.resend({
+      type: 'signup',
+      email: address,
+      options: { emailRedirectTo: CONFIRMATION_REDIRECT }
+    });
+    if (error) throw error;
     return data;
   }
 
@@ -166,6 +178,7 @@
   window.ShowduinoSupabase = Object.freeze({
     enabled,
     register,
+    resendConfirmation,
     signIn,
     signOut,
     onAuthChanged,

--- a/supabase/email-templates/confirm-signup.html
+++ b/supabase/email-templates/confirm-signup.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#080808;color:#f5f0e8;font-family:Arial,Helvetica,sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#080808;padding:32px 12px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:620px;background:#11100e;border:1px solid #3e2d12;border-radius:18px;overflow:hidden;box-shadow:0 18px 50px rgba(0,0,0,.45);">
+            <tr>
+              <td style="padding:38px 32px 18px;text-align:center;background:linear-gradient(180deg,#14110c 0%,#0d0d0c 100%);">
+                <div style="font-family:Georgia,'Times New Roman',serif;font-size:48px;line-height:1;color:#d9a441;font-weight:700;letter-spacing:-2px;">Showduino</div>
+                <div style="margin-top:12px;color:#c8bda8;font-size:12px;letter-spacing:3px;text-transform:uppercase;">Show Control So Good, It’s Frightening.</div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:30px 34px 8px;">
+                <div style="font-size:12px;letter-spacing:2px;text-transform:uppercase;color:#d9a441;font-weight:700;">Welcome to Showduino</div>
+                <h1 style="margin:10px 0 14px;font-size:28px;line-height:1.2;color:#ffffff;">Confirm your email address</h1>
+                <p style="margin:0 0 16px;color:#cfc8bc;font-size:16px;line-height:1.65;">Your Showduino ID is almost ready. Confirm your email address to unlock cloud-saved productions and Showduino Studio.</p>
+                <p style="margin:0 0 26px;color:#cfc8bc;font-size:16px;line-height:1.65;">Tap the button below to finish creating your account.</p>
+                <table role="presentation" cellspacing="0" cellpadding="0" style="margin:0 auto 28px;">
+                  <tr>
+                    <td align="center" bgcolor="#d9a441" style="border-radius:8px;">
+                      <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:14px 28px;color:#120d05;text-decoration:none;font-size:15px;font-weight:800;letter-spacing:.3px;">Confirm Email Address</a>
+                    </td>
+                  </tr>
+                </table>
+                <div style="border-top:1px solid #2c261e;padding-top:22px;margin-top:4px;">
+                  <p style="margin:0 0 8px;color:#9d9488;font-size:13px;line-height:1.6;">After confirmation you’ll return to Showduino automatically.</p>
+                  <p style="margin:0;color:#756f67;font-size:12px;line-height:1.6;">If you didn’t create a Showduino account, you can safely ignore this email.</p>
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:26px 34px 34px;text-align:center;">
+                <a href="https://show-duino.com" style="color:#d9a441;text-decoration:none;font-size:13px;">show-duino.com</a>
+                <div style="margin-top:14px;color:#615c55;font-size:11px;letter-spacing:1px;">SHOWDUINO · HAUNTSYNC · GOREFX</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/supabase/email-templates/recovery.html
+++ b/supabase/email-templates/recovery.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#080808;color:#f5f0e8;font-family:Arial,Helvetica,sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#080808;padding:32px 12px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:620px;background:#11100e;border:1px solid #3e2d12;border-radius:18px;overflow:hidden;">
+            <tr>
+              <td style="padding:38px 32px 18px;text-align:center;">
+                <div style="font-family:Georgia,'Times New Roman',serif;font-size:48px;line-height:1;color:#d9a441;font-weight:700;letter-spacing:-2px;">Showduino</div>
+                <div style="margin-top:12px;color:#c8bda8;font-size:12px;letter-spacing:3px;text-transform:uppercase;">Show Control So Good, It’s Frightening.</div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:30px 34px 8px;">
+                <div style="font-size:12px;letter-spacing:2px;text-transform:uppercase;color:#d9a441;font-weight:700;">Showduino ID</div>
+                <h1 style="margin:10px 0 14px;font-size:28px;color:#fff;">Reset your password</h1>
+                <p style="margin:0 0 24px;color:#cfc8bc;font-size:16px;line-height:1.65;">We received a request to reset your Showduino password. Use the button below to continue.</p>
+                <table role="presentation" cellspacing="0" cellpadding="0" style="margin:0 auto 28px;">
+                  <tr>
+                    <td align="center" bgcolor="#d9a441" style="border-radius:8px;">
+                      <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:14px 28px;color:#120d05;text-decoration:none;font-size:15px;font-weight:800;">Reset Password</a>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:0;color:#756f67;font-size:12px;line-height:1.6;border-top:1px solid #2c261e;padding-top:20px;">If you didn’t request a password reset, you can safely ignore this email.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:26px 34px 34px;text-align:center;">
+                <a href="https://show-duino.com" style="color:#d9a441;text-decoration:none;font-size:13px;">show-duino.com</a>
+                <div style="margin-top:14px;color:#615c55;font-size:11px;letter-spacing:1px;">SHOWDUINO · HAUNTSYNC · GOREFX</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## What this fixes

This fixes the signup problem where Supabase confirmation emails could return users to `localhost:3000` instead of the real Showduino website.

### Confirmation flow
- Confirmation emails now always return to `https://show-duino.com/account.html?confirmed=1`.
- The account page recognises confirmation returns and shows a clear welcome/success message.
- Expired or already-used confirmation links now get a friendly explanation instead of a raw auth error.
- Adds a Resend confirmation button so users can recover without creating another account.
- Sign-in errors are rewritten in plain language so new users know whether they need to confirm first.

### Branded email assets
- Adds official Showduino confirmation-email HTML.
- Adds official Showduino password-recovery email HTML.
- Branding follows the gold/black Showduino identity and the “Show Control So Good, It’s Frightening.” strapline.

### Verified root cause
Supabase auth logs show the original confirmation itself succeeded, but the redirect target was localhost. The website fix therefore targets the return-address problem rather than changing account storage or security.

No database schema or project-storage changes are included.