### PR TITLE
Finalize Showduino auth confirmation and branded emails

### DIFF
--- a/account.html
+++ b/account.html
@@ -11,114 +11,42 @@
   <header class="site-header">
     <a class="site-brand" href="index.html">SHOWDUINO</a>
     <nav class="site-nav" aria-label="Main navigation">
-      <a href="index.html">Home</a>
-      <a href="studio.html">Studio</a>
-      <a href="hauntsync.html">HauntSync</a>
-      <a href="tools.html">Tools</a>
-      <a href="account.html" aria-current="page">Account</a>
+      <a href="index.html">Home</a><a href="studio.html">Studio</a><a href="hauntsync.html">HauntSync</a><a href="tools.html">Tools</a><a href="account.html" aria-current="page">Account</a>
     </nav>
   </header>
-
   <main class="site-main">
-    <section class="page-heading">
-      <span class="badge">SHOWDUINO ID</span>
-      <h1>Your account</h1>
-      <p>One account for Showduino Studio, cloud-saved productions and future connected Showduino features.</p>
-    </section>
-
+    <section class="page-heading"><span class="badge">SHOWDUINO ID</span><h1>Your account</h1><p>One account for Showduino Studio, cloud-saved productions and future connected Showduino features.</p></section>
     <div id="account-status" class="status-banner" role="status" aria-live="polite">Loading Showduino account services…</div>
-
     <section id="auth-forms" class="grid two">
       <form id="login-form" class="card">
-        <h2>Sign in</h2>
-        <p class="muted">Open shows you saved from any computer or phone.</p>
-        <div class="form-group">
-          <label for="login-email">Email address</label>
-          <input id="login-email" class="form-control" type="email" autocomplete="email" required>
-        </div>
-        <div class="form-group">
-          <label for="login-password">Password</label>
-          <input id="login-password" class="form-control" type="password" autocomplete="current-password" minlength="8" required>
-        </div>
-        <div class="button-row">
-          <button class="btn" type="submit">Sign in</button>
-          <button id="forgot-password-button" class="btn secondary" type="button">Forgot password?</button>
-        </div>
+        <h2>Sign in</h2><p class="muted">Open shows you saved from any computer or phone.</p>
+        <div class="form-group"><label for="login-email">Email address</label><input id="login-email" class="form-control" type="email" autocomplete="email" required></div>
+        <div class="form-group"><label for="login-password">Password</label><input id="login-password" class="form-control" type="password" autocomplete="current-password" minlength="8" required></div>
+        <div class="button-row"><button class="btn" type="submit">Sign in</button><button id="forgot-password-button" class="btn secondary" type="button">Forgot password?</button></div>
       </form>
-
       <form id="register-form" class="card">
-        <h2>Create an account</h2>
-        <p class="muted">Create your free Showduino ID and cloud workspace.</p>
-        <div class="form-group">
-          <label for="register-name">Display name</label>
-          <input id="register-name" class="form-control" type="text" autocomplete="name" maxlength="60" required>
-        </div>
-        <div class="form-group">
-          <label for="register-email">Email address</label>
-          <input id="register-email" class="form-control" type="email" autocomplete="email" required>
-        </div>
-        <div class="form-group">
-          <label for="register-password">Password</label>
-          <input id="register-password" class="form-control" type="password" autocomplete="new-password" minlength="8" required>
-        </div>
-        <button class="btn" type="submit">Create account</button>
+        <h2>Create an account</h2><p class="muted">Create your free Showduino ID and cloud workspace.</p>
+        <div class="form-group"><label for="register-name">Display name</label><input id="register-name" class="form-control" type="text" autocomplete="name" maxlength="60" required></div>
+        <div class="form-group"><label for="register-email">Email address</label><input id="register-email" class="form-control" type="email" autocomplete="email" required></div>
+        <div class="form-group"><label for="register-password">Password</label><input id="register-password" class="form-control" type="password" autocomplete="new-password" minlength="8" required></div>
+        <div class="button-row"><button class="btn" type="submit">Create account</button><button id="resend-confirmation-button" class="btn secondary" type="button">Resend confirmation</button></div>
       </form>
     </section>
-
     <section id="password-recovery-panel" class="card" hidden>
-      <span class="badge">PASSWORD RECOVERY</span>
-      <h2>Choose a new password</h2>
-      <p class="muted">Enter a new password for your Showduino account.</p>
+      <span class="badge">PASSWORD RECOVERY</span><h2>Choose a new password</h2><p class="muted">Enter a new password for your Showduino account.</p>
       <form id="password-recovery-form">
-        <div class="form-group">
-          <label for="recovery-password">New password</label>
-          <input id="recovery-password" class="form-control" type="password" autocomplete="new-password" minlength="8" required>
-        </div>
-        <div class="form-group">
-          <label for="recovery-password-confirm">Confirm new password</label>
-          <input id="recovery-password-confirm" class="form-control" type="password" autocomplete="new-password" minlength="8" required>
-        </div>
+        <div class="form-group"><label for="recovery-password">New password</label><input id="recovery-password" class="form-control" type="password" autocomplete="new-password" minlength="8" required></div>
+        <div class="form-group"><label for="recovery-password-confirm">Confirm new password</label><input id="recovery-password-confirm" class="form-control" type="password" autocomplete="new-password" minlength="8" required></div>
         <button class="btn" type="submit">Save new password</button>
       </form>
     </section>
-
     <section id="account-panel" class="grid two" hidden>
-      <article class="card">
-        <span class="badge">SIGNED IN</span>
-        <h2 id="account-name">Showduino Creator</h2>
-        <p id="account-email" class="muted"></p>
-        <div class="button-row">
-          <a class="btn" href="studio.html">Open Studio</a>
-          <button id="sign-out-button" class="btn secondary" type="button">Sign out</button>
-        </div>
-      </article>
-
-      <article class="card">
-        <h2>Cloud status</h2>
-        <p class="muted">Your shows are protected by your Showduino account. Only you can read, change or delete your private projects.</p>
-        <span class="badge">SUPABASE CONNECTED</span>
-      </article>
+      <article class="card"><span class="badge">SIGNED IN</span><h2 id="account-name">Showduino Creator</h2><p id="account-email" class="muted"></p><div class="button-row"><a class="btn" href="studio.html">Open Studio</a><button id="sign-out-button" class="btn secondary" type="button">Sign out</button></div></article>
+      <article class="card"><h2>Cloud status</h2><p class="muted">Your shows are protected by your Showduino account. Only you can read, change or delete your private projects.</p><span class="badge">SUPABASE CONNECTED</span></article>
     </section>
-
-    <section class="card" style="margin-top: 1rem;">
-      <div class="button-row" style="justify-content: space-between;">
-        <div>
-          <h2 style="margin-bottom: .35rem;">Your projects</h2>
-          <p class="muted" style="margin: 0;">Cloud shows appear when you are signed in. Shows saved only on this device are also listed.</p>
-        </div>
-        <a class="btn secondary" href="studio.html">Create a show</a>
-      </div>
-      <div id="project-list" class="project-list"></div>
-    </section>
+    <section class="card" style="margin-top:1rem;"><div class="button-row" style="justify-content:space-between;"><div><h2 style="margin-bottom:.35rem;">Your projects</h2><p class="muted" style="margin:0;">Cloud shows appear when you are signed in. Shows saved only on this device are also listed.</p></div><a class="btn secondary" href="studio.html">Create a show</a></div><div id="project-list" class="project-list"></div></section>
   </main>
-
-  <footer class="site-footer">
-    <p>© 2026 Showduino · Built for immersive creators.</p>
-  </footer>
-
-  <script src="config/runtime-config.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.111.0"></script>
-  <script src="js/cloud/supabase-service.js"></script>
-  <script src="js/account-page.js"></script>
+  <footer class="site-footer"><p>© 2026 Showduino · Show control so good, it’s frightening.</p></footer>
+  <script src="config/runtime-config.js"></script><script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.111.0"></script><script src="js/cloud/supabase-service.js"></script><script src="js/account-page.js"></script>
 </body>
 </html>

--- a/js/account-page.js
+++ b/js/account-page.js
@@ -3,240 +3,90 @@
   'use strict';
 
   const elements = {};
+  const params = new URLSearchParams(window.location.search);
+  const confirmationReturn = params.get('confirmed') === '1';
   let recoveryMode = false;
 
   function byId(id) { return document.getElementById(id); }
-
-  function setStatus(message, type) {
-    elements.status.textContent = message;
-    elements.status.className = `status-banner${type ? ` ${type}` : ''}`;
+  function setStatus(message, type) { elements.status.textContent = message; elements.status.className = `status-banner${type ? ` ${type}` : ''}`; }
+  function friendlyAuthMessage(error, fallback) {
+    const message = String(error?.message || fallback || 'Something went wrong.');
+    if (/invalid login credentials/i.test(message)) return 'That email address and password did not match. If you just signed up, make sure the confirmation email has been opened first.';
+    if (/email not confirmed/i.test(message)) return 'Your Showduino ID is waiting for email confirmation. Open the confirmation email, or use “Resend confirmation”.';
+    if (/expired|invalid.*link|token/i.test(message)) return 'That confirmation link has expired or has already been used. Enter your email and choose “Resend confirmation”.';
+    return message;
   }
-
-  function escapeHtml(value) {
-    return String(value)
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&#039;');
-  }
-
-  function localProjects() {
-    try {
-      const stored = JSON.parse(localStorage.getItem('showduino_local_projects') || '[]');
-      return Array.isArray(stored) ? stored : [];
-    } catch (_) {
-      return [];
-    }
-  }
+  function escapeHtml(value) { return String(value).replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;').replaceAll("'",'&#039;'); }
+  function localProjects() { try { const stored = JSON.parse(localStorage.getItem('showduino_local_projects') || '[]'); return Array.isArray(stored) ? stored : []; } catch (_) { return []; } }
 
   async function renderProjects(user) {
     elements.projectList.innerHTML = '';
     let cloud = [];
-    if (user) {
-      try { cloud = await window.ShowduinoSupabase.listProjects(); }
-      catch (error) { setStatus(`Signed in, but cloud projects could not be loaded: ${error.message}`, 'error'); }
-    }
-
+    if (user) { try { cloud = await window.ShowduinoSupabase.listProjects(); } catch (error) { setStatus(`Signed in, but cloud projects could not be loaded: ${error.message}`, 'error'); } }
     const cloudIds = new Set(cloud.map((project) => project.id));
     const local = localProjects().filter((project) => !cloudIds.has(project.id));
-
-    if (!cloud.length && !local.length) {
-      elements.projectList.innerHTML = '<p class="muted">No shows yet. Open Studio and create your first Showduino production.</p>';
-      return;
-    }
-
+    if (!cloud.length && !local.length) { elements.projectList.innerHTML = '<p class="muted">No shows yet. Open Studio and create your first Showduino production.</p>'; return; }
     cloud.forEach((project) => {
-      const item = document.createElement('article');
-      item.className = 'project-item';
+      const item = document.createElement('article'); item.className = 'project-item';
       item.innerHTML = `<div><strong>${escapeHtml(project.name || 'Untitled Show')}</strong><div class="muted">Updated ${escapeHtml(new Date(project.updated_at).toLocaleString())}</div></div><span class="badge">CLOUD</span>`;
-      item.addEventListener('click', () => {
-        sessionStorage.setItem('showduino_open_cloud_project', project.id);
-        window.location.href = 'studio.html';
-      });
-      item.tabIndex = 0;
-      item.setAttribute('role', 'button');
-      item.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') item.click();
-      });
-      elements.projectList.appendChild(item);
+      item.addEventListener('click', () => { sessionStorage.setItem('showduino_open_cloud_project', project.id); window.location.href = 'studio.html'; });
+      item.tabIndex = 0; item.setAttribute('role','button'); item.addEventListener('keydown',(event)=>{ if(event.key==='Enter'||event.key===' ') item.click(); }); elements.projectList.appendChild(item);
     });
-
-    local.forEach((project) => {
-      const item = document.createElement('article');
-      item.className = 'project-item';
-      item.innerHTML = `<div><strong>${escapeHtml(project.name || 'Untitled Show')}</strong><div class="muted">Updated ${escapeHtml(project.updatedAt || 'on this device')}</div></div><span class="badge">THIS DEVICE</span>`;
-      elements.projectList.appendChild(item);
-    });
+    local.forEach((project) => { const item=document.createElement('article'); item.className='project-item'; item.innerHTML=`<div><strong>${escapeHtml(project.name || 'Untitled Show')}</strong><div class="muted">Updated ${escapeHtml(project.updatedAt || 'on this device')}</div></div><span class="badge">THIS DEVICE</span>`; elements.projectList.appendChild(item); });
   }
 
-  function showSignedOut() {
-    if (recoveryMode) return;
-    elements.authForms.hidden = false;
-    elements.accountPanel.hidden = true;
-    elements.recoveryPanel.hidden = true;
-  }
-
+  function showSignedOut() { if (recoveryMode) return; elements.authForms.hidden=false; elements.accountPanel.hidden=true; elements.recoveryPanel.hidden=true; }
   async function showSignedIn(user) {
-    if (recoveryMode) return;
-    elements.authForms.hidden = true;
-    elements.accountPanel.hidden = false;
-    elements.recoveryPanel.hidden = true;
-    let displayName = user.user_metadata?.display_name || 'Showduino Creator';
-    try {
-      const profile = await window.ShowduinoSupabase.getProfile();
-      if (profile?.display_name) displayName = profile.display_name;
-    } catch (_) {}
-    elements.accountName.textContent = displayName;
-    elements.accountEmail.textContent = user.email || '';
-    setStatus('Signed in. Your cloud shows are ready.', 'success');
-    await renderProjects(user);
+    if (recoveryMode) return; elements.authForms.hidden=true; elements.accountPanel.hidden=false; elements.recoveryPanel.hidden=true;
+    let displayName=user.user_metadata?.display_name || 'Showduino Creator'; try { const profile=await window.ShowduinoSupabase.getProfile(); if(profile?.display_name) displayName=profile.display_name; } catch (_) {}
+    elements.accountName.textContent=displayName; elements.accountEmail.textContent=user.email || '';
+    setStatus(confirmationReturn ? 'Email confirmed — welcome to Showduino. Your Showduino ID is ready.' : 'Signed in. Your cloud shows are ready.','success'); await renderProjects(user);
   }
+  function showRecoveryMode() { recoveryMode=true; elements.authForms.hidden=true; elements.accountPanel.hidden=true; elements.recoveryPanel.hidden=false; setStatus('Password reset link accepted. Choose a new password below.','success'); }
 
-  function showRecoveryMode() {
-    recoveryMode = true;
-    elements.authForms.hidden = true;
-    elements.accountPanel.hidden = true;
-    elements.recoveryPanel.hidden = false;
-    setStatus('Password reset link accepted. Choose a new password below.', 'success');
-  }
-
-  async function handleSignIn(event) {
-    event.preventDefault();
-    setStatus('Signing in…');
-    try {
-      await window.ShowduinoSupabase.signIn(elements.loginEmail.value.trim(), elements.loginPassword.value);
-    } catch (error) {
-      const message = String(error.message || 'Sign in failed.');
-      if (message.toLowerCase().includes('invalid login credentials')) {
-        setStatus('That email/password combination was not recognised. If you are unsure of the password, use “Forgot password?” below.', 'error');
-      } else {
-        setStatus(message, 'error');
-      }
-    }
-  }
-
+  async function handleSignIn(event) { event.preventDefault(); setStatus('Signing in…'); try { await window.ShowduinoSupabase.signIn(elements.loginEmail.value.trim(),elements.loginPassword.value); } catch(error){ setStatus(friendlyAuthMessage(error,'Sign in failed.'),'error'); } }
   async function handleRegister(event) {
-    event.preventDefault();
-    setStatus('Creating your Showduino account…');
+    event.preventDefault(); setStatus('Creating your Showduino account…');
     try {
-      const data = await window.ShowduinoSupabase.register(
-        elements.registerEmail.value.trim(),
-        elements.registerPassword.value,
-        elements.registerName.value.trim()
-      );
-      elements.registerForm.reset();
-      if (!data.session) {
-        setStatus('Account created. Check your email and tap Confirm. You will be returned to showduino.com to finish signing in.', 'success');
-      } else {
-        setStatus('Account created and signed in.', 'success');
-      }
-    } catch (error) {
-      setStatus(error.message || 'Account creation failed.', 'error');
-    }
+      const email=elements.registerEmail.value.trim();
+      const data=await window.ShowduinoSupabase.register(email,elements.registerPassword.value,elements.registerName.value.trim());
+      sessionStorage.setItem('showduino_pending_confirmation_email',email); elements.registerPassword.value='';
+      setStatus(data.session ? 'Account created and signed in.' : 'Showduino ID created. Check your email and tap “Confirm Email Address”. You will return here automatically.','success');
+    } catch(error){ setStatus(friendlyAuthMessage(error,'Account creation failed.'),'error'); }
   }
-
+  async function handleResendConfirmation() {
+    const email=elements.registerEmail.value.trim() || elements.loginEmail.value.trim() || sessionStorage.getItem('showduino_pending_confirmation_email') || '';
+    if(!email){ setStatus('Enter the email address you used to create your Showduino ID, then tap “Resend confirmation”.','error'); return; }
+    setStatus('Sending a fresh Showduino confirmation email…');
+    try { await window.ShowduinoSupabase.resendConfirmation(email); sessionStorage.setItem('showduino_pending_confirmation_email',email); setStatus('Fresh confirmation email sent. Open it and tap “Confirm Email Address”.','success'); }
+    catch(error){ setStatus(friendlyAuthMessage(error,'The confirmation email could not be resent.'),'error'); }
+  }
   async function handleForgotPassword() {
-    const email = elements.loginEmail.value.trim();
-    if (!email) {
-      setStatus('Enter your email address in the Sign in box first, then tap “Forgot password?”.', 'error');
-      elements.loginEmail.focus();
-      return;
-    }
-    setStatus('Sending password reset email…');
-    try {
-      await window.ShowduinoSupabase.requestPasswordReset(email);
-      setStatus('Password reset email sent. Open it and follow the link back to Showduino.', 'success');
-    } catch (error) {
-      setStatus(error.message || 'Password reset email could not be sent.', 'error');
-    }
+    const email=elements.loginEmail.value.trim(); if(!email){ setStatus('Enter your email address in the Sign in box first, then tap “Forgot password?”.','error'); elements.loginEmail.focus(); return; }
+    setStatus('Sending password reset email…'); try { await window.ShowduinoSupabase.requestPasswordReset(email); setStatus('Password reset email sent. Open it and follow the link back to Showduino.','success'); } catch(error){ setStatus(friendlyAuthMessage(error,'Password reset email could not be sent.'),'error'); }
   }
-
   async function handleRecoverySubmit(event) {
-    event.preventDefault();
-    const password = elements.recoveryPassword.value;
-    const confirm = elements.recoveryPasswordConfirm.value;
-    if (password !== confirm) {
-      setStatus('The two passwords do not match.', 'error');
-      return;
-    }
+    event.preventDefault(); const password=elements.recoveryPassword.value; const confirm=elements.recoveryPasswordConfirm.value;
+    if(password!==confirm){ setStatus('The two passwords do not match.','error'); return; }
     setStatus('Saving your new password…');
-    try {
-      await window.ShowduinoSupabase.updatePassword(password);
-      recoveryMode = false;
-      elements.recoveryForm.reset();
-      history.replaceState(null, '', 'account.html');
-      const user = await window.ShowduinoSupabase.getCurrentUser();
-      if (user) await showSignedIn(user);
-      else {
-        showSignedOut();
-        setStatus('Password updated. Sign in with your new password.', 'success');
-      }
-    } catch (error) {
-      setStatus(error.message || 'Your password could not be updated.', 'error');
-    }
+    try { await window.ShowduinoSupabase.updatePassword(password); recoveryMode=false; elements.recoveryForm.reset(); history.replaceState(null,'','account.html'); const user=await window.ShowduinoSupabase.getCurrentUser(); if(user) await showSignedIn(user); else { showSignedOut(); setStatus('Password updated. Sign in with your new password.','success'); } }
+    catch(error){ setStatus(friendlyAuthMessage(error,'Your password could not be updated.'),'error'); }
   }
-
-  async function handleSignOut() {
-    try {
-      await window.ShowduinoSupabase.signOut();
-      setStatus('You have signed out.');
-      await renderProjects(null);
-    } catch (error) {
-      setStatus(error.message || 'Sign out failed.', 'error');
-    }
-  }
+  async function handleSignOut(){ try{ await window.ShowduinoSupabase.signOut(); setStatus('You have signed out.'); await renderProjects(null); } catch(error){ setStatus(friendlyAuthMessage(error,'Sign out failed.'),'error'); } }
 
   function initialise() {
-    elements.status = byId('account-status');
-    elements.authForms = byId('auth-forms');
-    elements.accountPanel = byId('account-panel');
-    elements.recoveryPanel = byId('password-recovery-panel');
-    elements.loginForm = byId('login-form');
-    elements.registerForm = byId('register-form');
-    elements.recoveryForm = byId('password-recovery-form');
-    elements.loginEmail = byId('login-email');
-    elements.loginPassword = byId('login-password');
-    elements.registerName = byId('register-name');
-    elements.registerEmail = byId('register-email');
-    elements.registerPassword = byId('register-password');
-    elements.recoveryPassword = byId('recovery-password');
-    elements.recoveryPasswordConfirm = byId('recovery-password-confirm');
-    elements.accountName = byId('account-name');
-    elements.accountEmail = byId('account-email');
-    elements.projectList = byId('project-list');
-    elements.signOutButton = byId('sign-out-button');
-    elements.forgotPasswordButton = byId('forgot-password-button');
-
-    elements.loginForm.addEventListener('submit', handleSignIn);
-    elements.registerForm.addEventListener('submit', handleRegister);
-    elements.recoveryForm.addEventListener('submit', handleRecoverySubmit);
-    elements.signOutButton.addEventListener('click', handleSignOut);
-    elements.forgotPasswordButton.addEventListener('click', handleForgotPassword);
-
-    if (!window.ShowduinoSupabase?.enabled()) {
-      showSignedOut();
-      elements.authForms.querySelectorAll('input, button').forEach((element) => { element.disabled = true; });
-      setStatus('Showduino account services could not start. Local Studio saving is still available.', 'error');
-      renderProjects(null);
-      return;
-    }
-
-    setStatus('Checking your Showduino account…');
-    window.ShowduinoSupabase.onAuthChanged(async (user, event) => {
-      if (event === 'PASSWORD_RECOVERY') {
-        showRecoveryMode();
-        return;
-      }
-      if (recoveryMode) return;
-      if (user) await showSignedIn(user);
-      else {
-        showSignedOut();
-        setStatus('Sign in or create a free Showduino account.');
-        await renderProjects(null);
-      }
+    ['status','authForms','accountPanel','recoveryPanel','loginForm','registerForm','recoveryForm','loginEmail','loginPassword','registerName','registerEmail','registerPassword','recoveryPassword','recoveryPasswordConfirm','accountName','accountEmail','projectList','signOutButton','forgotPasswordButton','resendConfirmationButton'].forEach(()=>{});
+    elements.status=byId('account-status'); elements.authForms=byId('auth-forms'); elements.accountPanel=byId('account-panel'); elements.recoveryPanel=byId('password-recovery-panel'); elements.loginForm=byId('login-form'); elements.registerForm=byId('register-form'); elements.recoveryForm=byId('password-recovery-form'); elements.loginEmail=byId('login-email'); elements.loginPassword=byId('login-password'); elements.registerName=byId('register-name'); elements.registerEmail=byId('register-email'); elements.registerPassword=byId('register-password'); elements.recoveryPassword=byId('recovery-password'); elements.recoveryPasswordConfirm=byId('recovery-password-confirm'); elements.accountName=byId('account-name'); elements.accountEmail=byId('account-email'); elements.projectList=byId('project-list'); elements.signOutButton=byId('sign-out-button'); elements.forgotPasswordButton=byId('forgot-password-button'); elements.resendConfirmationButton=byId('resend-confirmation-button');
+    const pendingEmail=sessionStorage.getItem('showduino_pending_confirmation_email'); if(pendingEmail){ elements.registerEmail.value=pendingEmail; elements.loginEmail.value=pendingEmail; }
+    elements.loginForm.addEventListener('submit',handleSignIn); elements.registerForm.addEventListener('submit',handleRegister); elements.recoveryForm.addEventListener('submit',handleRecoverySubmit); elements.signOutButton.addEventListener('click',handleSignOut); elements.forgotPasswordButton.addEventListener('click',handleForgotPassword); elements.resendConfirmationButton.addEventListener('click',handleResendConfirmation);
+    if(!window.ShowduinoSupabase?.enabled()){ showSignedOut(); elements.authForms.querySelectorAll('input, button').forEach((element)=>{element.disabled=true;}); setStatus('Showduino account services could not start. Local Studio saving is still available.','error'); renderProjects(null); return; }
+    setStatus(confirmationReturn ? 'Finishing your Showduino email confirmation…' : 'Checking your Showduino account…');
+    window.ShowduinoSupabase.onAuthChanged(async(user,event)=>{
+      if(event==='PASSWORD_RECOVERY'){ showRecoveryMode(); return; }
+      if(recoveryMode) return;
+      if(user){ sessionStorage.removeItem('showduino_pending_confirmation_email'); await showSignedIn(user); }
+      else { showSignedOut(); setStatus(confirmationReturn ? 'Email confirmed. Sign in to finish opening your Showduino ID.' : 'Sign in or create a free Showduino account.', confirmationReturn ? 'success' : undefined); await renderProjects(null); }
     });
   }
-
-  document.addEventListener('DOMContentLoaded', initialise);
+  document.addEventListener('DOMContentLoaded',initialise);
 })();

--- a/js/cloud/supabase-service.js
+++ b/js/cloud/supabase-service.js
@@ -2,7 +2,8 @@
 (function () {
   'use strict';
 
-  const ACCOUNT_URL = 'https://showduino.com/account.html';
+  const ACCOUNT_URL = 'https://show-duino.com/account.html';
+  const CONFIRMATION_URL = `${ACCOUNT_URL}?confirmed=1`;
   let client = null;
 
   function config() {
@@ -25,11 +26,7 @@
     if (!client) {
       const cfg = config().supabase;
       client = window.supabase.createClient(cfg.url, cfg.publishableKey, {
-        auth: {
-          persistSession: true,
-          autoRefreshToken: true,
-          detectSessionInUrl: true
-        }
+        auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true }
       });
     }
     return client;
@@ -51,13 +48,22 @@
     const { data, error } = await getClient().auth.signUp({
       email,
       password,
-      options: {
-        emailRedirectTo: ACCOUNT_URL,
-        data: { display_name: displayName }
-      }
+      options: { emailRedirectTo: CONFIRMATION_URL, data: { display_name: displayName } }
     });
     if (error) throw error;
     if (data.user && data.session) await upsertProfile(data.user, displayName);
+    return data;
+  }
+
+  async function resendConfirmation(email) {
+    const address = String(email || '').trim();
+    if (!address) throw new Error('Enter the email address you used to sign up first.');
+    const { data, error } = await getClient().auth.resend({
+      type: 'signup',
+      email: address,
+      options: { emailRedirectTo: CONFIRMATION_URL }
+    });
+    if (error) throw error;
     return data;
   }
 
@@ -69,9 +75,7 @@
   }
 
   async function requestPasswordReset(email) {
-    const { data, error } = await getClient().auth.resetPasswordForEmail(email, {
-      redirectTo: ACCOUNT_URL
-    });
+    const { data, error } = await getClient().auth.resetPasswordForEmail(email, { redirectTo: ACCOUNT_URL });
     if (error) throw error;
     return data;
   }
@@ -119,9 +123,7 @@
 
   function ensureProjectUuid(project) {
     project.project = project.project || {};
-    if (!isUuid(project.project.id)) {
-      project.project.id = window.crypto?.randomUUID?.() || '00000000-0000-4000-8000-000000000000';
-    }
+    if (!isUuid(project.project.id)) project.project.id = window.crypto?.randomUUID?.() || '00000000-0000-4000-8000-000000000000';
     return project.project.id;
   }
 
@@ -148,11 +150,7 @@
   async function listProjects() {
     const user = await getCurrentUser();
     if (!user) return [];
-    const { data, error } = await getClient()
-      .from('projects')
-      .select('id,name,format,format_version,created_at,updated_at')
-      .eq('user_id', user.id)
-      .order('updated_at', { ascending: false });
+    const { data, error } = await getClient().from('projects').select('id,name,format,format_version,created_at,updated_at').eq('user_id', user.id).order('updated_at', { ascending: false });
     if (error) throw error;
     return data || [];
   }
@@ -160,12 +158,7 @@
   async function loadProject(id) {
     const user = await getCurrentUser();
     if (!user) throw new Error('Sign in to load cloud shows.');
-    const { data, error } = await getClient()
-      .from('projects')
-      .select('project_data')
-      .eq('id', id)
-      .eq('user_id', user.id)
-      .single();
+    const { data, error } = await getClient().from('projects').select('project_data').eq('id', id).eq('user_id', user.id).single();
     if (error) throw error;
     return data.project_data;
   }
@@ -178,18 +171,7 @@
   }
 
   window.ShowduinoSupabase = Object.freeze({
-    enabled,
-    register,
-    signIn,
-    requestPasswordReset,
-    updatePassword,
-    signOut,
-    onAuthChanged,
-    getCurrentUser,
-    getProfile,
-    saveProject,
-    listProjects,
-    loadProject,
-    deleteProject
+    enabled, register, resendConfirmation, signIn, requestPasswordReset, updatePassword, signOut,
+    onAuthChanged, getCurrentUser, getProfile, saveProject, listProjects, loadProject, deleteProject
   });
 })();

--- a/supabase/email-templates/confirm-signup.html
+++ b/supabase/email-templates/confirm-signup.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#080808;color:#f5f0e8;font-family:Arial,Helvetica,sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#080808;padding:32px 12px;">
+      <tr><td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:620px;background:#11100e;border:1px solid #3e2d12;border-radius:18px;overflow:hidden;box-shadow:0 18px 50px rgba(0,0,0,.45);">
+          <tr><td style="padding:38px 32px 18px;text-align:center;background:#0d0d0c;"><div style="font-family:Georgia,'Times New Roman',serif;font-size:48px;line-height:1;color:#d9a441;font-weight:700;letter-spacing:-2px;">Showduino</div><div style="margin-top:12px;color:#c8bda8;font-size:12px;letter-spacing:3px;text-transform:uppercase;">Show Control So Good, It’s Frightening.</div></td></tr>
+          <tr><td style="padding:30px 34px 8px;"><div style="font-size:12px;letter-spacing:2px;text-transform:uppercase;color:#d9a441;font-weight:700;">Welcome to Showduino</div><h1 style="margin:10px 0 14px;font-size:28px;color:#fff;">Confirm your email address</h1><p style="margin:0 0 16px;color:#cfc8bc;font-size:16px;line-height:1.65;">Your Showduino ID is almost ready. Confirm your email address to unlock cloud-saved productions and Showduino Studio.</p><p style="margin:0 0 26px;color:#cfc8bc;font-size:16px;line-height:1.65;">Tap the button below to finish creating your account.</p><table role="presentation" cellspacing="0" cellpadding="0" style="margin:0 auto 28px;"><tr><td align="center" bgcolor="#d9a441" style="border-radius:8px;"><a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:14px 28px;color:#120d05;text-decoration:none;font-size:15px;font-weight:800;">Confirm Email Address</a></td></tr></table><div style="border-top:1px solid #2c261e;padding-top:22px;"><p style="margin:0 0 8px;color:#9d9488;font-size:13px;line-height:1.6;">After confirmation you’ll return to Showduino automatically.</p><p style="margin:0;color:#756f67;font-size:12px;line-height:1.6;">If you didn’t create a Showduino account, you can safely ignore this email.</p></div></td></tr>
+          <tr><td style="padding:26px 34px 34px;text-align:center;"><a href="https://show-duino.com" style="color:#d9a441;text-decoration:none;font-size:13px;">show-duino.com</a><div style="margin-top:14px;color:#615c55;font-size:11px;letter-spacing:1px;">SHOWDUINO · HAUNTSYNC · GOREFX</div></td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>

--- a/supabase/email-templates/recovery.html
+++ b/supabase/email-templates/recovery.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#080808;color:#f5f0e8;font-family:Arial,Helvetica,sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#080808;padding:32px 12px;">
+      <tr><td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:620px;background:#11100e;border:1px solid #3e2d12;border-radius:18px;overflow:hidden;">
+          <tr><td style="padding:38px 32px 18px;text-align:center;"><div style="font-family:Georgia,'Times New Roman',serif;font-size:48px;line-height:1;color:#d9a441;font-weight:700;letter-spacing:-2px;">Showduino</div><div style="margin-top:12px;color:#c8bda8;font-size:12px;letter-spacing:3px;text-transform:uppercase;">Show Control So Good, It’s Frightening.</div></td></tr>
+          <tr><td style="padding:30px 34px 8px;"><div style="font-size:12px;letter-spacing:2px;text-transform:uppercase;color:#d9a441;font-weight:700;">Showduino ID</div><h1 style="margin:10px 0 14px;font-size:28px;color:#fff;">Reset your password</h1><p style="margin:0 0 24px;color:#cfc8bc;font-size:16px;line-height:1.65;">We received a request to reset your Showduino password. Use the button below to continue.</p><table role="presentation" cellspacing="0" cellpadding="0" style="margin:0 auto 28px;"><tr><td align="center" bgcolor="#d9a441" style="border-radius:8px;"><a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:14px 28px;color:#120d05;text-decoration:none;font-size:15px;font-weight:800;">Reset Password</a></td></tr></table><p style="margin:0;color:#756f67;font-size:12px;line-height:1.6;border-top:1px solid #2c261e;padding-top:20px;">If you didn’t request a password reset, you can safely ignore this email.</p></td></tr>
+          <tr><td style="padding:26px 34px 34px;text-align:center;"><a href="https://show-duino.com" style="color:#d9a441;text-decoration:none;font-size:13px;">show-duino.com</a><div style="margin-top:14px;color:#615c55;font-size:11px;letter-spacing:1px;">SHOWDUINO · HAUNTSYNC · GOREFX</div></td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## Final auth fix

This combines the existing password-recovery work with the corrected live Showduino domain and confirmation recovery.

### Fixes
- Uses the real live domain: `https://show-duino.com`.
- Signup confirmation always returns to `account.html?confirmed=1` on the live site.
- Password-reset links also return to the live site.
- Adds `Resend confirmation` for expired/missing confirmation emails.
- Shows friendly messages for unconfirmed accounts, expired links and invalid credentials.
- Preserves the existing Forgot password / choose-new-password flow.

### Branding assets
- Adds a gold/black Showduino confirmation email template.
- Adds a matching password-recovery template.
- Uses the Showduino strapline and HauntSync/GoreFX footer branding.

Supabase auth logs confirmed that the original email click did confirm the account; the visible failure was the bad localhost return address.