### PR TITLE
Move Studio Inspector into a collapsible bottom drawer

### DIFF
--- a/css/studio-inspector-drawer.css
+++ b/css/studio-inspector-drawer.css
@@ -1,0 +1,132 @@
+/* Showduino Studio — Inspector drawer
+   The timeline is the primary workspace. The Inspector overlays from the bottom
+   only when a clip is selected, instead of permanently consuming timeline width. */
+
+.timeline-editor .timeline-main {
+  position: relative !important;
+}
+
+/* Tablet/desktop: take the Inspector out of the horizontal flex layout. */
+@media (min-width: 761px) {
+  .timeline-editor .tl-inspector {
+    display: block !important;
+    position: absolute !important;
+    z-index: 70 !important;
+    left: 220px !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    width: auto !important;
+    min-width: 0 !important;
+    height: min(34vh, 310px) !important;
+    max-height: 310px !important;
+    padding: 0 !important;
+    overflow-y: auto !important;
+    border-left: 0 !important;
+    border-top: 1px solid var(--studio-border, #2d3a46) !important;
+    background: #111820 !important;
+    box-shadow: 0 -18px 48px rgba(0,0,0,.58) !important;
+    transform: translateY(calc(100% + 8px)) !important;
+    transition: transform .2s ease !important;
+    pointer-events: none;
+  }
+
+  body.studio-inspector-open .timeline-editor .tl-inspector {
+    transform: translateY(0) !important;
+    pointer-events: auto;
+  }
+
+  /* The timeline column now receives all space that the Inspector used to take. */
+  .timeline-editor .tl-right {
+    flex: 1 1 auto !important;
+    min-width: 0 !important;
+    width: auto !important;
+  }
+
+  /* Tablet library is a little narrower so the timeline remains dominant. */
+  @media (max-width: 1000px) {
+    .timeline-editor .tl-left {
+      width: 180px !important;
+      min-width: 180px !important;
+    }
+    .timeline-editor .tl-inspector {
+      left: 180px !important;
+    }
+  }
+}
+
+/* Phone keeps the existing full-width bottom-sheet behaviour, but starts hidden. */
+@media (max-width: 760px) {
+  .timeline-editor .tl-inspector {
+    pointer-events: none;
+  }
+  body.studio-inspector-open .timeline-editor .tl-inspector {
+    pointer-events: auto;
+  }
+}
+
+/* Drawer header/close control injected by studio-inspector-drawer.js. */
+.studio-inspector-drawer-bar {
+  position: sticky;
+  z-index: 5;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 42px;
+  padding: 8px 12px;
+  background: rgba(17,24,32,.97);
+  border-bottom: 1px solid var(--studio-border, #2d3a46);
+  backdrop-filter: blur(10px);
+}
+
+.studio-inspector-drawer-label {
+  color: var(--studio-accent, #00e6c3);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.studio-inspector-close {
+  min-width: 34px;
+  min-height: 30px;
+  padding: 4px 10px;
+  border: 1px solid #344653;
+  border-radius: 6px;
+  background: #1a252e;
+  color: #dfe9ed;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.studio-inspector-close:hover,
+.studio-inspector-close:focus-visible {
+  color: var(--studio-accent, #00e6c3);
+  border-color: var(--studio-accent, #00e6c3);
+  outline: none;
+}
+
+.timeline-editor .tl-inspector > .inspector-shell {
+  padding: 10px 12px 18px;
+}
+
+/* On wider screens, make Inspector fields flow horizontally instead of becoming
+   a very tall form. This keeps the drawer compact. */
+@media (min-width: 900px) {
+  .timeline-editor .tl-inspector .inspector-shell {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(220px, 1fr));
+    gap: 10px;
+    align-items: start;
+  }
+
+  .timeline-editor .tl-inspector .inspector-head {
+    grid-column: 1 / -1;
+  }
+
+  .timeline-editor .tl-inspector .inspector-section {
+    margin: 0 !important;
+  }
+}

--- a/js/studio-inspector-drawer.js
+++ b/js/studio-inspector-drawer.js
@@ -1,0 +1,69 @@
+/* global TimelineEditor */
+(function () {
+  'use strict';
+
+  if (typeof TimelineEditor === 'undefined') {
+    console.error('[Showduino Inspector Drawer] TimelineEditor is unavailable.');
+    return;
+  }
+
+  const originalShowInspector = TimelineEditor.prototype._showInspector;
+
+  function closeInspector() {
+    document.body.classList.remove('studio-inspector-open');
+  }
+
+  function addDrawerBar(panel) {
+    if (!panel || panel.querySelector('.studio-inspector-drawer-bar')) return;
+
+    const bar = document.createElement('div');
+    bar.className = 'studio-inspector-drawer-bar';
+
+    const label = document.createElement('span');
+    label.className = 'studio-inspector-drawer-label';
+    label.textContent = 'Inspector';
+
+    const close = document.createElement('button');
+    close.className = 'studio-inspector-close';
+    close.type = 'button';
+    close.setAttribute('aria-label', 'Close Inspector');
+    close.title = 'Close Inspector';
+    close.textContent = '×';
+    close.addEventListener('click', closeInspector);
+
+    bar.append(label, close);
+    panel.prepend(bar);
+  }
+
+  TimelineEditor.prototype._showInspector = function (clipId) {
+    originalShowInspector.call(this, clipId);
+
+    const clipExists = Boolean(clipId && this._clips().some((clip) => clip.id === clipId));
+    if (!clipExists) {
+      closeInspector();
+      return;
+    }
+
+    addDrawerBar(this._inspectorPanel);
+    document.body.classList.add('studio-inspector-open');
+  };
+
+  // If a selected clip is deleted, make sure the now-empty drawer disappears.
+  const originalDeleteClip = TimelineEditor.prototype._deleteClip;
+  if (typeof originalDeleteClip === 'function') {
+    TimelineEditor.prototype._deleteClip = function (clipId) {
+      const result = originalDeleteClip.call(this, clipId);
+      if (!this._selectedClipId || !this._clips().some((clip) => clip.id === this._selectedClipId)) {
+        closeInspector();
+      }
+      return result;
+    };
+  }
+
+  // Public helper used by the existing mobile Inspector button.
+  window.ShowduinoInspectorDrawer = Object.freeze({
+    open() { document.body.classList.add('studio-inspector-open'); },
+    close: closeInspector,
+    toggle() { document.body.classList.toggle('studio-inspector-open'); }
+  });
+})();

--- a/studio.html
+++ b/studio.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="css/studio-timeline-mixer.css">
     <link rel="stylesheet" href="css/studio-3.css">
     <link rel="stylesheet" href="css/timeline-drop-zones.css">
+    <link rel="stylesheet" href="css/studio-inspector-drawer.css">
     <style>
         .studio-project-actions { display:flex; gap:.35rem; flex-wrap:wrap; align-items:center; }
         .studio-action-btn { min-height:36px; padding:.45rem .7rem; border:1px solid var(--border-color); border-radius:5px; background:#333; color:var(--text-color); cursor:pointer; text-decoration:none; }
@@ -90,6 +91,7 @@
     <script src="js/timeline-fx-daw.js"></script>
     <script src="js/timeline-drop-zones.js"></script>
     <script src="js/timeline-professional-inspector.js"></script>
+    <script src="js/studio-inspector-drawer.js"></script>
     <script src="js/timeline-mixer.js"></script>
     <script src="js/audio_browser.js"></script>
     <script src="js/dmx_editor.js"></script>


### PR DESCRIPTION
## What this changes

The Inspector no longer permanently consumes the right side of the Studio timeline.

- Timeline keeps the full available width.
- Inspector becomes a bottom drawer.
- Drawer opens automatically when a clip is selected.
- Drawer closes with a clear × button.
- Existing Inspector controls and editing logic are preserved.
- Mobile keeps the existing bottom-sheet behaviour.
- Tablet/desktop Inspector fields flow across the drawer to keep it compact.

This is a presentation/layout change only; project data, Supabase and deployment behaviour are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive Inspector drawer to the timeline editor.
  * Inspector panels now slide in from the bottom on tablet and desktop layouts.
  * Added a labeled header, close controls, and improved hover and focus states.
  * Timeline space expands when the Inspector is open, with optimized layouts for wider screens.
  * Inspector automatically closes when no clip is selected or the selected clip is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->