### PR TITLE
Restore DAW-style Studio clip and track editing

### DIFF
--- a/js/studio-inspector-drawer.js
+++ b/js/studio-inspector-drawer.js
@@ -35,20 +35,27 @@
     panel.prepend(bar);
   }
 
-  TimelineEditor.prototype._showInspector = function (clipId) {
-    originalShowInspector.call(this, clipId);
+  function selectedClipExists(editor, clipId) {
+    return Boolean(editor && clipId && editor._clips().some((clip) => clip.id === clipId));
+  }
 
-    const clipExists = Boolean(clipId && this._clips().some((clip) => clip.id === clipId));
-    if (!clipExists) {
+  function renderInspector(editor, clipId) {
+    if (!selectedClipExists(editor, clipId)) {
       closeInspector();
-      return;
+      return false;
     }
 
-    addDrawerBar(this._inspectorPanel);
-    document.body.classList.add('studio-inspector-open');
+    originalShowInspector.call(editor, clipId);
+    addDrawerBar(editor._inspectorPanel);
+    return true;
+  }
+
+  // Selection keeps the Inspector content current, but never opens the drawer.
+  // This preserves click-and-drag as the primary DAW interaction.
+  TimelineEditor.prototype._showInspector = function (clipId) {
+    renderInspector(this, clipId);
   };
 
-  // If a selected clip is deleted, make sure the now-empty drawer disappears.
   const originalDeleteClip = TimelineEditor.prototype._deleteClip;
   if (typeof originalDeleteClip === 'function') {
     TimelineEditor.prototype._deleteClip = function (clipId) {
@@ -60,10 +67,23 @@
     };
   }
 
-  // Public helper used by the existing mobile Inspector button.
+  function openInspector(clipId) {
+    const editor = window.timelineEditor;
+    const targetClipId = clipId || (editor && editor._selectedClipId);
+    if (!renderInspector(editor, targetClipId)) return false;
+    document.body.classList.add('studio-inspector-open');
+    return true;
+  }
+
   window.ShowduinoInspectorDrawer = Object.freeze({
-    open() { document.body.classList.add('studio-inspector-open'); },
+    open: openInspector,
     close: closeInspector,
-    toggle() { document.body.classList.toggle('studio-inspector-open'); }
+    toggle(clipId) {
+      if (document.body.classList.contains('studio-inspector-open')) {
+        closeInspector();
+        return false;
+      }
+      return openInspector(clipId);
+    }
   });
 })();

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -258,8 +258,22 @@ class TimelineEditor {
       this._rulerEl.scrollLeft = this._scrollLeft;
       this._markerTrackEl.style.transform = `translateX(-${this._scrollLeft}px)`;
       this._rulerEl.style.backgroundPositionX = `-${this._scrollLeft}px`;
+
+      if (!this._syncingVerticalScroll) {
+        this._syncingVerticalScroll = true;
+        this._trackListEl.scrollTop = this._canvasScroll.scrollTop;
+        this._syncingVerticalScroll = false;
+      }
+
       this._updateRuler();
       this._updateGridCanvas();
+    });
+
+    this._trackListEl.addEventListener('scroll', () => {
+      if (this._syncingVerticalScroll) return;
+      this._syncingVerticalScroll = true;
+      this._canvasScroll.scrollTop = this._trackListEl.scrollTop;
+      this._syncingVerticalScroll = false;
     });
 
     return right;
@@ -450,6 +464,15 @@ class TimelineEditor {
       this._selectClip(clip.id);
     });
 
+    el.addEventListener('dblclick', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      this._selectClip(clip.id);
+      if (window.ShowduinoInspectorDrawer) {
+        window.ShowduinoInspectorDrawer.open(clip.id);
+      }
+    });
+
     el.addEventListener('contextmenu', e => {
       e.preventDefault();
       this._showClipContextMenu(e, clip.id);
@@ -468,37 +491,69 @@ class TimelineEditor {
   /* ── Drag ────────────────────────────────────────────────────── */
 
   _startDrag(e, clipId) {
-    const track = this._getClipTrack(clipId);
-    if (track && track.locked) return;
+    const sourceTrack = this._getClipTrack(clipId);
+    if (sourceTrack && sourceTrack.locked) return;
+
     e.preventDefault();
     const clip = this._clips().find(c => c.id === clipId);
     if (!clip) return;
+
     this._selectClip(clipId);
 
     const startX = e.clientX;
+    const startY = e.clientY;
     const origStartMs = clip.startMs;
-    const canvasRect = this._canvas.getBoundingClientRect();
+    const sortedTracks = this._tracks().slice().sort((a, b) => a.order - b.order);
+    let moved = false;
+
+    this._dragState = { clipId };
 
     const onMove = mv => {
       const dx = mv.clientX - startX;
+      const dy = mv.clientY - startY;
+      if (!moved && Math.hypot(dx, dy) < 3) return;
+      moved = true;
+
       const dMs = dx / this._pxPerMs;
       let newStart = Math.max(0, origStartMs + dMs);
       if (this._snapEnabled) newStart = this._snapValue(newStart);
 
-      if (!this._overlaps(clipId, clip.trackId, newStart, clip.durationMs)) {
-        clip.startMs = newStart;
-        const el = this._canvas.querySelector(`[data-clip-id="${clipId}"]`);
-        if (el) el.style.left = this._msToX(newStart) + 'px';
-        this._syncPlayheadPosition();
-        this._updateTimecodeDisplay();
+      const canvasRect = this._canvas.getBoundingClientRect();
+      const pointerY = mv.clientY - canvasRect.top;
+      const targetIndex = Math.max(0, Math.min(sortedTracks.length - 1, Math.floor(pointerY / this._trackHeight)));
+      const candidateTrack = sortedTracks[targetIndex];
+      const targetTrack = candidateTrack &&
+        candidateTrack.type === clip.type &&
+        !candidateTrack.locked
+          ? candidateTrack
+          : this._tracks().find(track => track.id === clip.trackId);
+
+      if (!targetTrack || this._overlaps(clipId, targetTrack.id, newStart, clip.durationMs)) return;
+
+      clip.startMs = newStart;
+      clip.trackId = targetTrack.id;
+
+      const renderedTrackIndex = sortedTracks.findIndex(track => track.id === targetTrack.id);
+      const el = this._canvas.querySelector(`[data-clip-id="${clipId}"]`);
+      if (el) {
+        el.style.left = this._msToX(newStart) + 'px';
+        el.style.top = (renderedTrackIndex * this._trackHeight + 8) + 'px';
       }
+
+      this._syncPlayheadPosition();
+      this._updateTimecodeDisplay();
     };
 
     const onUp = () => {
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
-      this._pushUndo();
-      this._autosave();
+      this._dragState = null;
+
+      if (moved) {
+        this._pushUndo();
+        this._autosave();
+        this._showInspector(clipId);
+      }
     };
 
     document.addEventListener('mousemove', onMove);
@@ -709,10 +764,23 @@ class TimelineEditor {
 
   addTrack(type = 'audio', name = null) {
     this._pushUndo();
+
     const order = this._tracks().length;
-    const track = SHDOModel.createTrack(type, name, order);
+    const typeCount = this._tracks().filter(track => track.type === type).length;
+    const title = type.charAt(0).toUpperCase() + type.slice(1);
+    const trackName = name || `${title} Track ${typeCount + 1}`;
+    const track = SHDOModel.createTrack(type, trackName, order);
+
     this._project().tracks.push(track);
     this._renderTracks();
+
+    requestAnimationFrame(() => {
+      this._canvasScroll.scrollTop = this._canvasScroll.scrollHeight;
+      this._trackListEl.scrollTop = this._trackListEl.scrollHeight;
+      const header = this._trackListEl.querySelector(`[data-track-id="${track.id}"]`);
+      if (header) header.scrollIntoView({ block: 'nearest' });
+    });
+
     this._autosave();
     this._log(`Track added: ${track.name}`, 'INFO');
     return track;
@@ -832,7 +900,10 @@ class TimelineEditor {
       menu.appendChild(li);
     };
 
-    item('✏️ Inspect',    () => this._selectClip(clipId));
+    item('✏️ Inspect',    () => {
+      this._selectClip(clipId);
+      if (window.ShowduinoInspectorDrawer) window.ShowduinoInspectorDrawer.open(clipId);
+    });
     item('⊕ Duplicate',  () => this._duplicateClip(clipId));
     item('✂️ Split at Playhead', () => this._splitClip(clipId));
     item('✕ Delete',     () => this._deleteClip(clipId));


### PR DESCRIPTION
## What changed

- Stops the Inspector drawer opening automatically when a clip is merely selected.
- Keeps single-click for selection and click-drag for timeline editing.
- Opens the Inspector deliberately through double-click or the existing **Inspect** context action.
- Adds horizontal and vertical clip movement between compatible, unlocked tracks.
- Keeps overlap protection and timeline snapping during movement.
- Synchronizes vertical scrolling between track headers and timeline lanes.
- Gives repeated tracks clear numbered names and scrolls newly-created lanes into view.

## Root cause

PR #26 wrapped `TimelineEditor._showInspector()` and added the open drawer class every time selection changed. Since drag begins by selecting the clip, every edit gesture opened the drawer. The original desktop drag implementation also changed only `startMs`; it did not support moving a clip between tracks. Track headers and timeline lanes used separate unsynchronized vertical scrollers, so newly-added lanes could appear missing.

## User impact

Studio behaves like a DAW again: select without losing workspace, drag audio along time, drag vertically to another audio lane, and add more numbered tracks that remain aligned and visible.

## Validation

- JavaScript syntax validation passed for `js/timeline.js`.
- JavaScript syntax validation passed for `js/studio-inspector-drawer.js`.
- Branch compared against `main`: two intended files only.
- Browser interaction and Cloudflare preview testing remain to be completed before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Open clip inspectors by double-clicking a clip or selecting **Inspect** from its context menu.
  - Move clips vertically between compatible, unlocked tracks by dragging.
  - New tracks receive descriptive sequential names and are brought into view automatically.
  - Track list and timeline scrolling now remain synchronized.

- **Bug Fixes**
  - Prevented clips from overlapping during movement.
  - Invalid clip selections no longer open the inspector.
  - Inspector content refreshes correctly after moving clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->