### PR TITLE
Add universal Studio lanes and three-dot Inspector menu

### DIFF
--- a/js/shdo_model.js
+++ b/js/shdo_model.js
@@ -33,7 +33,7 @@ class SHDOModel {
 
   static createTrack(type = 'audio', name = null, order = 0) {
     const colors = {
-      audio: '#00aaff', fx: '#aa00ff', relay: '#ff8800', lighting: '#ffff00',
+      mixed: '#7f8c98', audio: '#00aaff', fx: '#aa00ff', relay: '#ff8800', lighting: '#ffff00',
       pixel: '#00ffcc', dmx: '#ff0066', prop: '#33cc33', trigger: '#ff3333'
     };
     return {

--- a/js/timeline-drop-zones.js
+++ b/js/timeline-drop-zones.js
@@ -36,14 +36,19 @@
     return editor._snapEnabled ? editor._snapValue(rawMs) : rawMs;
   }
 
-  function ensureTrack(editor, preset) {
-    const existing = editor._tracks().find((track) => track.type === preset.type && !track.locked);
+  function ensureTrack(editor, preset, startMs) {
+    const durationMs = preset.durationMs || 5000;
+    const existing = editor._tracks().find((track) =>
+      !track.locked && !editor._overlaps(null, track.id, startMs, durationMs)
+    );
     if (existing) return existing;
-    return editor.addTrack(preset.type, `${titleFor(preset.type)} Track ${editor._tracks().filter((track) => track.type === preset.type).length + 1}`);
+
+    const laneNumber = editor._tracks().filter((track) => track.type === 'mixed').length + 1;
+    return editor.addTrack('mixed', `Lane ${laneNumber}`);
   }
 
   function insertPreset(editor, preset, startMs) {
-    const track = ensureTrack(editor, preset);
+    const track = ensureTrack(editor, preset, startMs);
     if (typeof editor._insertPreset === 'function') {
       return editor._insertPreset(track.id, preset, startMs);
     }
@@ -105,7 +110,7 @@
 
     const hint = document.createElement('div');
     hint.className = 'timeline-lane-hint';
-    hint.textContent = `Drop ${titleFor(track.type)} here`;
+    hint.textContent = 'Drop any clip here';
     row.appendChild(hint);
 
     const activate = (event) => {

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -96,10 +96,11 @@ class TimelineEditor {
     bar.style.cssText = 'display:flex;gap:4px;padding:6px 8px;background:#2a2a2a;border-bottom:1px solid #444;flex-wrap:wrap;align-items:center;flex-shrink:0;';
 
     const addGroup = this._toolbarGroup('Add Track:');
-    const trackTypes = ['audio','fx','relay','lighting','pixel','dmx','prop','trigger'];
-    const trackIcons = { audio:'🎵', fx:'✨', relay:'⚡', lighting:'💡', pixel:'🌈', dmx:'🎛', prop:'⚙️', trigger:'🎯' };
+    const trackTypes = ['mixed','audio','fx','relay','lighting','pixel','dmx','prop','trigger'];
+    const trackIcons = { mixed:'＋', audio:'🎵', fx:'✨', relay:'⚡', lighting:'💡', pixel:'🌈', dmx:'🎛', prop:'⚙️', trigger:'🎯' };
     trackTypes.forEach(t => {
-      const btn = this._toolbarBtn(trackIcons[t] + ' ' + t.charAt(0).toUpperCase() + t.slice(1), () => this.addTrack(t));
+      const label = t === 'mixed' ? 'Lane' : t.charAt(0).toUpperCase() + t.slice(1);
+      const btn = this._toolbarBtn(trackIcons[t] + ' ' + label, () => this.addTrack(t));
       btn.title = 'Add ' + t + ' track';
       addGroup.appendChild(btn);
     });
@@ -523,11 +524,9 @@ class TimelineEditor {
       const pointerY = mv.clientY - canvasRect.top;
       const targetIndex = Math.max(0, Math.min(sortedTracks.length - 1, Math.floor(pointerY / this._trackHeight)));
       const candidateTrack = sortedTracks[targetIndex];
-      const targetTrack = candidateTrack &&
-        candidateTrack.type === clip.type &&
-        !candidateTrack.locked
-          ? candidateTrack
-          : this._tracks().find(track => track.id === clip.trackId);
+      const targetTrack = candidateTrack && !candidateTrack.locked
+        ? candidateTrack
+        : this._tracks().find(track => track.id === clip.trackId);
 
       if (!targetTrack || this._overlaps(clipId, targetTrack.id, newStart, clip.durationMs)) return;
 
@@ -768,8 +767,10 @@ class TimelineEditor {
 
     const order = this._tracks().length;
     const typeCount = this._tracks().filter(track => track.type === type).length;
-    const title = type.charAt(0).toUpperCase() + type.slice(1);
-    const trackName = name || `${title} Track ${typeCount + 1}`;
+    const title = type === 'mixed' ? 'Lane' : type.charAt(0).toUpperCase() + type.slice(1);
+    const trackName = name || (type === 'mixed'
+      ? `Lane ${typeCount + 1}`
+      : `${title} Track ${typeCount + 1}`);
     const track = SHDOModel.createTrack(type, trackName, order);
 
     this._project().tracks.push(track);

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -145,6 +145,16 @@ class TimelineEditor {
 
     // Marker
     bar.appendChild(this._toolbarBtn('📌 Marker', () => this._addMarkerAtPlayhead()));
+
+    // Selected clip actions live under one deliberate three-dot menu.
+    const moreBtn = this._toolbarBtn('⋮', event => this._showTimelineMoreMenu(event.currentTarget));
+    moreBtn.classList.add('timeline-more-btn');
+    moreBtn.setAttribute('aria-label', 'More timeline actions');
+    moreBtn.setAttribute('aria-haspopup', 'menu');
+    moreBtn.title = 'More timeline actions';
+    moreBtn.style.fontSize = '18px';
+    moreBtn.style.lineHeight = '1';
+    bar.appendChild(moreBtn);
     bar.appendChild(sep());
 
     // Project
@@ -462,15 +472,6 @@ class TimelineEditor {
     el.addEventListener('click', e => {
       if (this._dragState) return;
       this._selectClip(clip.id);
-    });
-
-    el.addEventListener('dblclick', e => {
-      e.preventDefault();
-      e.stopPropagation();
-      this._selectClip(clip.id);
-      if (window.ShowduinoInspectorDrawer) {
-        window.ShowduinoInspectorDrawer.open(clip.id);
-      }
     });
 
     el.addEventListener('contextmenu', e => {
@@ -880,6 +881,80 @@ class TimelineEditor {
     this._renderClip(copy);
     this._selectClip(copy.id);
     this._autosave();
+  }
+
+  _showTimelineMoreMenu(anchor) {
+    const existing = document.getElementById('tl-more-menu');
+    if (existing) {
+      existing.remove();
+      return;
+    }
+
+    const selectedClip = this.getSelectedClip();
+    const menu = document.createElement('div');
+    menu.id = 'tl-more-menu';
+    menu.setAttribute('role', 'menu');
+
+    const rect = anchor.getBoundingClientRect();
+    menu.style.cssText = `
+      position:fixed;
+      top:${rect.bottom + 6}px;
+      left:${Math.max(8, Math.min(rect.left, window.innerWidth - 210))}px;
+      width:200px;
+      padding:5px;
+      background:#202a32;
+      border:1px solid #465764;
+      border-radius:6px;
+      box-shadow:0 10px 28px rgba(0,0,0,.55);
+      z-index:10000;
+    `;
+
+    const addItem = (label, action, enabled = true) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.setAttribute('role', 'menuitem');
+      button.textContent = label;
+      button.disabled = !enabled;
+      button.style.cssText = `
+        display:block;
+        width:100%;
+        padding:8px 10px;
+        border:0;
+        border-radius:4px;
+        background:transparent;
+        color:${enabled ? '#e8f0f2' : '#6d7b82'};
+        text-align:left;
+        font:12px monospace;
+        cursor:${enabled ? 'pointer' : 'not-allowed'};
+      `;
+
+      if (enabled) {
+        button.addEventListener('mouseenter', () => { button.style.background = '#30404b'; });
+        button.addEventListener('mouseleave', () => { button.style.background = 'transparent'; });
+        button.addEventListener('click', () => {
+          menu.remove();
+          action();
+        });
+      }
+
+      menu.appendChild(button);
+    };
+
+    addItem('Inspector', () => {
+      if (window.ShowduinoInspectorDrawer) {
+        window.ShowduinoInspectorDrawer.open(selectedClip.id);
+      }
+    }, Boolean(selectedClip));
+
+    addItem('Duplicate clip', () => this._duplicateClip(selectedClip.id), Boolean(selectedClip));
+    addItem('Delete clip', () => this._deleteClip(selectedClip.id), Boolean(selectedClip));
+
+    document.body.appendChild(menu);
+
+    const closeMenu = event => {
+      if (!menu.contains(event.target) && event.target !== anchor) menu.remove();
+    };
+    setTimeout(() => document.addEventListener('pointerdown', closeMenu, { once: true }), 0);
   }
 
   _showClipContextMenu(e, clipId) {


### PR DESCRIPTION
## What changed

- Adds a clear three-dot **More** menu containing Inspector, Duplicate clip, and Delete clip.
- Removes double-click Inspector opening.
- Adds a first-class **+ Lane** control for universal timeline lanes.
- Allows every clip type to be dragged onto every unlocked lane.
- Preserves each clip's own type and parameters after it moves.
- Uses any free lane when a preset is dropped.
- Automatically creates another universal lane when simultaneous clips would otherwise collide.
- Changes lane guidance to **Drop any clip here**.

## Why

Studio needs to behave as a true multitrack show timeline. Lines are layers for simultaneous show content, not restrictions that force audio, FX, lighting, and other clip types onto one dedicated row.

## Validation

- JavaScript syntax validation passed for `js/timeline.js`.
- JavaScript syntax validation passed for `js/shdo_model.js`.
- JavaScript syntax validation passed for `js/timeline-drop-zones.js`.
- Branch is four commits ahead of and zero commits behind `main`.
- Diff is limited to the three intended Studio timeline/model files.
- Cloudflare preview interaction testing remains before merge.
